### PR TITLE
Fixed an issue with Critical Process Died BSOD

### DIFF
--- a/FFUDevelopment/BuildFFUVM.ps1
+++ b/FFUDevelopment/BuildFFUVM.ps1
@@ -202,7 +202,7 @@ param(
     [ValidateSet(512, 4096)]
     [uint32]$LogicalSectorSizeBytes = 512
 )
-$version = '2306.1.2'
+$version = '2309.1'
 
 #Check if Hyper-V feature is installed (requires only checks the module)
 $osInfo = Get-WmiObject -Class Win32_OperatingSystem
@@ -1009,11 +1009,10 @@ function New-FFU {
         WriteLog "FFU file name: $FFUFileName"
         $FFUFile = "$FFUCaptureLocation\$FFUFileName"
         #Capture the FFU
-        WriteLog 'Capturing FFU from VHDX file'
         #Invoke-Process cmd "/c ""$DandIEnv"" && dism /Capture-FFU /ImageFile:$FFUFile /CaptureDrive:\\.\PhysicalDrive$($vhdxDisk.DiskNumber) /Name:$($winverinfo.Name)$($winverinfo.DisplayVersion)$($winverinfo.SKU) /Compress:Default"
         Invoke-Process cmd "/c dism /Capture-FFU /ImageFile:$FFUFile /CaptureDrive:\\.\PhysicalDrive$($vhdxDisk.DiskNumber) /Name:$($winverinfo.Name)$($winverinfo.DisplayVersion)$($winverinfo.SKU) /Compress:Default"
         WriteLog 'FFU Capture complete'
-        WriteLog 'Sleeping 60 seconds before dismount of VHDX'
+        #WriteLog 'Sleeping 60 seconds before dismount of VHDX'
         Dismount-ScratchVhdx -VhdxPath $VHDXPath
     }
 
@@ -1149,6 +1148,11 @@ Function Get-WindowsVersionInfo {
     
     WriteLog "Unloading registry"
     Invoke-Process reg "unload HKLM\FFU"
+    #This prevents Critical Process Died errors you can have during deployment of the FFU. Capturing from very fast disks (NVME) can cause the capture to happen faster than Windows is ready for.
+    WriteLog 'Sleep 15 seconds to allow registry to completely unload'
+    Start-sleep 15
+
+
 
     return @{
 

--- a/FFUDevelopment/WinPECaptureFFUFiles/CaptureFFU.ps1
+++ b/FFUDevelopment/WinPECaptureFFUFiles/CaptureFFU.ps1
@@ -1,5 +1,5 @@
-#Modify the net use W: \\192.168.1.158\FFUCaptureShare /user:ffu_user 0ef0258a-0447-496e-846f-23d2d1f0e334
-net use W: \\192.168.1.158\FFUCaptureShare /user:ffu_user 0ef0258a-0447-496e-846f-23d2d1f0e334
+#Modify the net use W: \\192.168.1.158\FFUCaptureShare /user:ffu_user ddb1f077-3eed-433c-b4d9-7b8cd54ce727
+net use W: \\192.168.1.158\FFUCaptureShare /user:ffu_user ddb1f077-3eed-433c-b4d9-7b8cd54ce727
 
 $AssignDriveLetter = 'x:\AssignDriveLetter.txt'
 Start-Process -FilePath diskpart.exe -ArgumentList "/S $AssignDriveLetter" -Wait -ErrorAction Stop | Out-Null
@@ -59,6 +59,9 @@ Remove-Variable CurrentBuild
 Remove-Variable DisplayVersion
 Remove-Variable Office
 reg unload "HKLM\FFU"
+#This prevents Critical Process Died errors you can have during deployment of the FFU - may not happen during capture from WinPE, but adding here to be consistent with VHDX capture
+WriteLog 'Sleep 15 seconds to allow registry to completely unload'
+Start-sleep 15
 
 Start-Process -FilePath dism.exe -ArgumentList $dismArgs -Wait -PassThru -ErrorAction Stop | Out-Null
 #Copy DISM log to Host

--- a/FFUDevelopment/WinPEDeployFFUFiles/ApplyFFU.ps1
+++ b/FFUDevelopment/WinPEDeployFFUFiles/ApplyFFU.ps1
@@ -117,7 +117,7 @@ $LogFileName = 'ScriptLog.txt'
 $USBDrive = Get-USBDrive
 New-item -Path $USBDrive -Name $LogFileName -ItemType "file" -Force | Out-Null
 $LogFile = $USBDrive + $LogFilename
-$version = '2306.1.2'
+$version = '2309.1'
 WriteLog 'Begin Logging'
 WriteLog "Script version: $version"
 


### PR DESCRIPTION
When using -installapps $false when capturing a FFU, a Critical Process Died BSOD would happen when deploying the FFU and Windows attempted to load.

When capturing the FFU, the registry is loaded to grab the Windows version information to create the FFU file name. After unloading the registry, the FFU is captured. This process can happen too fast on certain hard drives (NVME). A 15 second delay was added after the unloading of the registry to allow for the process to complete before the FFU is captured.