### PR TITLE
2309.2

### DIFF
--- a/FFUDevelopment/BuildFFUVM.ps1
+++ b/FFUDevelopment/BuildFFUVM.ps1
@@ -1281,10 +1281,10 @@ Function New-DeploymentUSB {
 
     foreach ($USBDrive in $USBDrives) {
         $Counter++
-        WriteLog "Fromatting drive $Counter out of $USBDrivesCount"
+        WriteLog "Fromatting USB drive $Counter out of $USBDrivesCount"
         # Format the USB drive
         $DiskNumber = $USBDrive.DeviceID.Replace("\\.\PHYSICALDRIVE", "")
-        WriteLog "Disk number is $DiskNumber"
+        WriteLog "Physical Disk number is $DiskNumber for USB drive $Counter out of $USBDrivesCount"
         #Delete these two lines
         # Clear-Disk -Number $DiskNumber -RemoveData -RemoveOEM -Confirm:$false 
         # Get-Disk -number $disknumber | select *

--- a/FFUDevelopment/WinPECaptureFFUFiles/CaptureFFU.ps1
+++ b/FFUDevelopment/WinPECaptureFFUFiles/CaptureFFU.ps1
@@ -60,9 +60,7 @@ Remove-Variable DisplayVersion
 Remove-Variable Office
 reg unload "HKLM\FFU"
 #This prevents Critical Process Died errors you can have during deployment of the FFU - may not happen during capture from WinPE, but adding here to be consistent with VHDX capture
-WriteLog 'Sleep 60 seconds to allow registry to completely unload'
 Start-sleep 60
-
 Start-Process -FilePath dism.exe -ArgumentList $dismArgs -Wait -PassThru -ErrorAction Stop | Out-Null
 #Copy DISM log to Host
 xcopy X:\Windows\logs\dism\dism.log W:\ /Y | Out-Null

--- a/FFUDevelopment/WinPECaptureFFUFiles/CaptureFFU.ps1
+++ b/FFUDevelopment/WinPECaptureFFUFiles/CaptureFFU.ps1
@@ -60,8 +60,8 @@ Remove-Variable DisplayVersion
 Remove-Variable Office
 reg unload "HKLM\FFU"
 #This prevents Critical Process Died errors you can have during deployment of the FFU - may not happen during capture from WinPE, but adding here to be consistent with VHDX capture
-WriteLog 'Sleep 15 seconds to allow registry to completely unload'
-Start-sleep 15
+WriteLog 'Sleep 60 seconds to allow registry to completely unload'
+Start-sleep 60
 
 Start-Process -FilePath dism.exe -ArgumentList $dismArgs -Wait -PassThru -ErrorAction Stop | Out-Null
 #Copy DISM log to Host

--- a/FFUDevelopment/WinPEDeployFFUFiles/ApplyFFU.ps1
+++ b/FFUDevelopment/WinPEDeployFFUFiles/ApplyFFU.ps1
@@ -117,7 +117,7 @@ $LogFileName = 'ScriptLog.txt'
 $USBDrive = Get-USBDrive
 New-item -Path $USBDrive -Name $LogFileName -ItemType "file" -Force | Out-Null
 $LogFile = $USBDrive + $LogFilename
-$version = '2309.1'
+$version = '2309.2'
 WriteLog 'Begin Logging'
 WriteLog "Script version: $version"
 


### PR DESCRIPTION
New Features

**Multiple USB Drive Support**
You can now plug in multiple USB drives (even using a USB hub) to create multiple USB drives for deployment. This is great for partners or customers who need to provide USB drives to their employees to image a large number of devices. Open an issue if you see any problems with this

**Robocopy support**
Replaced Copy-Item with Robocopy when copying content to the USB drive(s). Copy-Item uses buffered IO, which can take a long time to copy large files. Robocopy with the /J switch allows for unbuffered IO support, which reduces the amount of time to copy.

**Better error handling**
Prior to 2309.2, if the script failed or you manually killed the script (ctrl+c, or closing the PowerShell window), the environment would end up in a bad state and you had to do a number of things to manually clean up the environment. Added a new function called Get-FFUEnvironment and a new text file called dirty.txt that gets created in the FFUDevelopment folder. When the script starts, it checks for the dirty.txt file and if it sees it, Get-FFUEnvironment runs and cleans out a number of things to help ensure the next run will complete successfully. Open an issue if you still see problems when the script fails and the next run of the script fails. 


Bug Fixes
- In 2309.1, added a 15 second sleep to allow for the registry to unload to fix a Critical Process Died error on deployment. In this build, increased that to 60 seconds. 
- Fixed an issue where the script was incorrectly detecting the USB drive boot and deploy drive letters which caused issues when attempting to copy the WinPE files to the boot partition.