### PR TITLE
2401.1 Update

### DIFF
--- a/FFUDevelopment/Apps/Office/DeployFFU.xml
+++ b/FFUDevelopment/Apps/Office/DeployFFU.xml
@@ -1,5 +1,5 @@
 <Configuration ID="efa6df21-a106-428e-8eaa-d89a5dda6030">
-  <Add OfficeClientEdition="64" Channel="MonthlyEnterprise">
+  <Add OfficeClientEdition="64" Channel="Current">
     <Product ID="O365ProPlusRetail">
       <Language ID="MatchOS" />
       <ExcludeApp ID="Access" />

--- a/FFUDevelopment/Apps/Office/DownloadFFU.xml
+++ b/FFUDevelopment/Apps/Office/DownloadFFU.xml
@@ -1,5 +1,5 @@
 <Configuration ID="efa6df21-a106-428e-8eaa-d89a5dda6030">
-  <Add SourcePath="C:\FFUDevelopment\Apps\Office" OfficeClientEdition="64" Channel="MonthlyEnterprise">
+  <Add SourcePath="C:\FFUDevelopment\Apps\Office" OfficeClientEdition="64" Channel="Current">
     <Product ID="O365ProPlusRetail">
       <Language ID="MatchOS" />
       <ExcludeApp ID="Access" />

--- a/FFUDevelopment/BuildFFUVM.ps1
+++ b/FFUDevelopment/BuildFFUVM.ps1
@@ -200,7 +200,12 @@ param(
     [ValidateSet('consumer', 'business')]
     [string]$MediaType = 'consumer',
     [ValidateSet(512, 4096)]
-    [uint32]$LogicalSectorSizeBytes = 512
+    [uint32]$LogicalSectorSizeBytes = 512,
+    #Will be used in future release
+    [bool]$CopyDrivers,
+    [bool]$CopyPPKG,
+    [bool]$CopyUnattend,
+    [bool]$RemoveFFU
 )
 $version = '2309.2'
 

--- a/FFUDevelopment/WinPECaptureFFUFiles/CaptureFFU.ps1
+++ b/FFUDevelopment/WinPECaptureFFUFiles/CaptureFFU.ps1
@@ -60,6 +60,7 @@ Remove-Variable DisplayVersion
 Remove-Variable Office
 reg unload "HKLM\FFU"
 #This prevents Critical Process Died errors you can have during deployment of the FFU - may not happen during capture from WinPE, but adding here to be consistent with VHDX capture
+Write-Host "Sleeping for 60 seconds to allow registry to unload prior to capture"
 Start-sleep 60
 Start-Process -FilePath dism.exe -ArgumentList $dismArgs -Wait -PassThru -ErrorAction Stop | Out-Null
 #Copy DISM log to Host

--- a/FFUDevelopment/WinPEDeployFFUFiles/ApplyFFU.ps1
+++ b/FFUDevelopment/WinPEDeployFFUFiles/ApplyFFU.ps1
@@ -117,7 +117,7 @@ $LogFileName = 'ScriptLog.txt'
 $USBDrive = Get-USBDrive
 New-item -Path $USBDrive -Name $LogFileName -ItemType "file" -Force | Out-Null
 $LogFile = $USBDrive + $LogFilename
-$version = '2312.1'
+$version = '2401.1'
 WriteLog 'Begin Logging'
 WriteLog "Script version: $version"
 

--- a/FFUDevelopment/WinPEDeployFFUFiles/ApplyFFU.ps1
+++ b/FFUDevelopment/WinPEDeployFFUFiles/ApplyFFU.ps1
@@ -117,7 +117,7 @@ $LogFileName = 'ScriptLog.txt'
 $USBDrive = Get-USBDrive
 New-item -Path $USBDrive -Name $LogFileName -ItemType "file" -Force | Out-Null
 $LogFile = $USBDrive + $LogFilename
-$version = '2309.2'
+$version = '2312.1'
 WriteLog 'Begin Logging'
 WriteLog "Script version: $version"
 


### PR DESCRIPTION
BuildFFUVM.ps1

- Added -CopyDrivers boolean parameter to control the ability to copy drivers to the USB drive in the deploy partition drivers folder. 
- Changed version varaible to 2401.1
- When creating the scratch VHDX, switched it to create a dynamic VHDX instead of fixed
- Fixed an issue where adding drivers to the FFU would sometimes fail and would cause the script to exit unexpectedly
- Added -optimize boolean parameter to control whether the FFU is optimized or not. This defaults to $true and in most cases should be left this way.
- Fixed an issue where if the script failed to create the FFU and the old VM was left behind, it wouldn't clean it up if the VM was in the running state. Will now turn off any running VM with a name prefix of _FFU- and then remove any VMs with a name _FFU- if the environment is flagged as dirty.
- Fixed an issue where devices that ship with UFS drives were unable to image due to the script setting a LogicalSectorSizeBytes value of 512. If you're creating a FFU for devices that have UFS drives, you'll need to set -LogicalSectorSizeBytes 4096. 
- There's a known issue where adding drivers to a FFU that has a LogicalSectorSizeBytes value of 4096. Added some code to prevent allowing this to happen. Please use -copydrivers $true as a workaround for now. We're investigating whether this is a bug or not.
- Fixed an issue where VHDX only captures (i.e. where -installapps $false) would not install Windows updates. 
- Changed Office deployment to use Current channel instead of Monthly enterprise. If you want to change to Monthly Enterprise channel, it's recommended to leverage Intune.