### PR TITLE
Move location of command that cleans up the WinSXS folder

### DIFF
--- a/FFUDevelopment/Apps/InstallAppsandSysprep.cmd
+++ b/FFUDevelopment/Apps/InstallAppsandSysprep.cmd
@@ -15,8 +15,5 @@ del c:\windows\panther\unattend\unattend.xml /F /Q
 del c:\windows\panther\unattend.xml /F /Q
 taskkill /IM sysprep.exe
 timeout /t 10
-REM Run Component Cleanup since dism /online /cleanup-image /analyzecomponentcleanup recommends it
-REM If adding latest CU, definitely need to do this to keep FFU size smaller
-dism /online /cleanup-image /startcomponentcleanup /resetbase
 REM Sysprep/Generalize
 c:\windows\system32\sysprep\sysprep.exe /quiet /generalize /oobe

--- a/FFUDevelopment/BuildFFUVM.ps1
+++ b/FFUDevelopment/BuildFFUVM.ps1
@@ -2240,10 +2240,13 @@ try {
     if ($UpdateLatestCU -or $UpdateLatestNet) {
         try {
             WriteLog "Adding KBs to $WindowsPartition"
-            Add-WindowsPackage -Path $WindowsPartition -PackagePath $KBPath | Out-Null
+            Add-WindowsPackage -Path $WindowsPartition -PackagePath $KBPath -PreventPending | Out-Null
             WriteLog "KBs added to $WindowsPartition"
             WriteLog "Removing $KBPath"
             Remove-Item -Path $KBPath -Recurse -Force | Out-Null
+	    WriteLog "Clean Up the WinSxS Folder"
+            Dism /Image:$WindowsPartition /Cleanup-Image /StartComponentCleanup /ResetBase | Out-Null
+            WriteLog "Clean Up the WinSxS Folder completed"
         }
         catch {
             Write-Host "Adding KB to VHDX failed with error $_"


### PR DESCRIPTION
Adding "-PreventPending" to the "add-windowspackage" command allows the dism cleanup of the winsxs folder command to be moved from the InstallAppsandSysprep.cmd script to right after the updates are added to the vhdx. The end result: 

FFU image size before: 11.836GB
FFU image size after: 11.190GB

![Image-Compare](https://github.com/rbalsleyMSFT/FFU/assets/167896478/b5b9e015-ce78-4032-b9e4-cc491dc2bcea)
