### PR TITLE
2405.1

### DIFF
--- a/FFUDevelopment/Apps/InstallAppsandSysprep.cmd
+++ b/FFUDevelopment/Apps/InstallAppsandSysprep.cmd
@@ -15,5 +15,22 @@ del c:\windows\panther\unattend\unattend.xml /F /Q
 del c:\windows\panther\unattend.xml /F /Q
 taskkill /IM sysprep.exe
 timeout /t 10
+REM Run disk cleanup (cleanmgr.exe) with all options enabled: https://learn.microsoft.com/en-us/troubleshoot/windows-server/backup-and-storage/automating-disk-cleanup-tool
+set rootkey=HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\VolumeCaches
+REM Per above doc, the Offline Pages Files subkey does not have stateflags value
+for /f "tokens=*" %%K in ('reg query "%rootkey%"') do (
+    echo %%K | findstr /i /c:"Offline Pages Files"
+    if errorlevel 1 (
+        reg add "%%K" /v StateFlags0000 /t REG_DWORD /d 2 /f
+    )
+)
+cleanmgr.exe /sagerun:0
+REM Remove the StateFlags0000 registry value
+for /f "tokens=*" %%K in ('reg query "%rootkey%"') do (
+    echo %%K | findstr /i /c:"Offline Pages Files"
+    if errorlevel 1 (
+        reg delete "%%K" /v StateFlags0000 /f
+    )
+)
 REM Sysprep/Generalize
 c:\windows\system32\sysprep\sysprep.exe /quiet /generalize /oobe

--- a/FFUDevelopment/Apps/InstallAppsandSysprep.cmd
+++ b/FFUDevelopment/Apps/InstallAppsandSysprep.cmd
@@ -15,8 +15,5 @@ del c:\windows\panther\unattend\unattend.xml /F /Q
 del c:\windows\panther\unattend.xml /F /Q
 taskkill /IM sysprep.exe
 timeout /t 10
-REM Run Component Cleanup since dism /online /cleanup-image /analyzecomponentcleanup recommends it
-REM If adding latest CU, definitely need to do this to keep FFU size smaller
-dism /online /cleanup-image /startcomponentcleanup /resetbase
 REM Sysprep/Generalize
 c:\windows\system32\sysprep\sysprep.exe /quiet /generalize /oobe

--- a/FFUDevelopment/BuildFFUVM.ps1
+++ b/FFUDevelopment/BuildFFUVM.ps1
@@ -2270,7 +2270,7 @@ try {
             WriteLog "Removing $KBPath"
             Remove-Item -Path $KBPath -Recurse -Force | Out-Null
 	        WriteLog "Clean Up the WinSxS Folder"
-            Dism /Image:$WindowsPartition /Cleanup-Image /StartComponentCleanup /ResetBase | Out-Null
+            Invoke-Process cmd "/c ""$DandIEnv"" && Dism /Image:$WindowsPartition /Cleanup-Image /StartComponentCleanup /ResetBase" | Out-Null
             WriteLog "Clean Up the WinSxS Folder completed"
         }
         catch {

--- a/FFUDevelopment/BuildFFUVM.ps1
+++ b/FFUDevelopment/BuildFFUVM.ps1
@@ -2240,10 +2240,13 @@ try {
     if ($UpdateLatestCU -or $UpdateLatestNet) {
         try {
             WriteLog "Adding KBs to $WindowsPartition"
-            Add-WindowsPackage -Path $WindowsPartition -PackagePath $KBPath | Out-Null
+            Add-WindowsPackage -Path $WindowsPartition -PackagePath $KBPath -PreventPending | Out-Null
             WriteLog "KBs added to $WindowsPartition"
             WriteLog "Removing $KBPath"
             Remove-Item -Path $KBPath -Recurse -Force | Out-Null
+	    WriteLog "Clean Up the WinSxS Folder"
+            Dism /Image:$WindowsPartition /Cleanup-Image /StartComponentCleanup /ResetBase | Out-Null
+            WriteLog "Clean Up the WinSxS Folder completed"
         }
         catch {
             Write-Host "Adding KB to VHDX failed with error $_"

--- a/FFUDevelopment/BuildFFUVM.ps1
+++ b/FFUDevelopment/BuildFFUVM.ps1
@@ -2269,7 +2269,7 @@ try {
             WriteLog "KBs added to $WindowsPartition"
             WriteLog "Removing $KBPath"
             Remove-Item -Path $KBPath -Recurse -Force | Out-Null
-	    WriteLog "Clean Up the WinSxS Folder"
+	        WriteLog "Clean Up the WinSxS Folder"
             Dism /Image:$WindowsPartition /Cleanup-Image /StartComponentCleanup /ResetBase | Out-Null
             WriteLog "Clean Up the WinSxS Folder completed"
         }

--- a/FFUDevelopment/BuildFFUVM.ps1
+++ b/FFUDevelopment/BuildFFUVM.ps1
@@ -1438,6 +1438,31 @@ function New-PEMedia {
     Remove-Item -Path "$WinPEFFUPath" -Recurse -Force
     WriteLog 'Cleanup complete'
 }
+
+function Optimize-FFUCaptureDrive {
+    param (
+        [string]$VhdxPath
+    )
+    try {
+        WriteLog 'Mounting VHDX for volume optimization'
+        Mount-VHD -Path $VhdxPath
+        WriteLog 'Defragmenting Windows partition...'
+        Optimize-Volume -DriveLetter W -Defrag -NormalPriority -Verbose
+        WriteLog 'Performing slab consolidation on Windows partition...'
+        Optimize-Volume -DriveLetter W -SlabConsolidate -NormalPriority -Verbose
+        WriteLog 'Dismounting VHDX'
+        Dismount-ScratchVhdx -VhdxPath $VhdxPath
+        WriteLog 'Mounting VHDX as read-only for optimization'
+        Mount-VHD -Path $VhdxPath -NoDriveLetter -ReadOnly
+        WriteLog 'Optimizing VHDX in full mode...'
+        Optimize-VHD -Path $VhdxPath -Mode Full
+        WriteLog 'Dismounting VHDX'
+        Dismount-ScratchVhdx -VhdxPath $VhdxPath
+    } catch {
+        throw $_
+    }
+}
+
 function New-FFU {
     param (
         [Parameter(Mandatory = $false)]
@@ -2367,6 +2392,7 @@ try {
             WriteLog 'Waiting for VM to shutdown'
         } while ($FFUVM.State -ne 'Off')
         WriteLog 'VM Shutdown'
+        Optimize-FFUCaptureDrive -VhdxPath $VHDXPath
         #Capture FFU file
         New-FFU $FFUVM.Name
     }

--- a/FFUDevelopment/BuildFFUVM.ps1
+++ b/FFUDevelopment/BuildFFUVM.ps1
@@ -283,7 +283,7 @@ param(
     [bool]$CleanupDeployISO = $true,
     [bool]$CleanupAppsISO = $true
 )
-$version = '2404.2'
+$version = '2405.1'
 
 #Check if Hyper-V feature is installed (requires only checks the module)
 $osInfo = Get-WmiObject -Class Win32_OperatingSystem

--- a/FFUDevelopment/WinPEDeployFFUFiles/ApplyFFU.ps1
+++ b/FFUDevelopment/WinPEDeployFFUFiles/ApplyFFU.ps1
@@ -117,7 +117,7 @@ $LogFileName = 'ScriptLog.txt'
 $USBDrive = Get-USBDrive
 New-item -Path $USBDrive -Name $LogFileName -ItemType "file" -Force | Out-Null
 $LogFile = $USBDrive + $LogFilename
-$version = '2404.3'
+$version = '2405.1'
 WriteLog 'Begin Logging'
 WriteLog "Script version: $version"
 

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ While we use this in Education at Microsoft, other industries can use it as well
 **2405.1**
 - Moved the resetbase command from within the VM to after servicing the VHDX. This will make it so the FFU size is smaller after the latest CU or .NET framework are installed. Thanks to Mike Kelly for the PR [Commit](https://github.com/rbalsleyMSFT/FFU/pull/24)
 - Some additional FFU size reduction enhancements (Thanks Zehadi Alam [Commit](https://github.com/rbalsleyMSFT/FFU/pull/25):
--- Disk cleanup is now run before sysprep to help reduce FFU file size
--- Before FFU capture, Optimize-FFU is run to defrag and slabconsolidate the VHDX
+  - Disk cleanup is now run before sysprep to help reduce FFU file size
+  - Before FFU capture, Optimize-FFU is run to defrag and slabconsolidate the VHDX
 
 
 **2404.3**

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ While we use this in Education at Microsoft, other industries can use it as well
 
 # Updates
 **2405.1**
-- Moved the resetbase command from within the VM to after servicing the VHDX. This will make it so the FFU size is smaller after the latest CU or .NET framework are installed. Thanks to Mike Kelly for the PR [Commit](https://github.com/rbalsleyMSFT/FFU/pull/24)
-- Some additional FFU size reduction enhancements (Thanks Zehadi Alam [Commit](https://github.com/rbalsleyMSFT/FFU/pull/25):
+- Moved the resetbase command from within the VM to after servicing the VHDX. This will make it so the FFU size is smaller after the latest CU or .NET framework are installed. (Thanks to Mike Kelly for the PR [Commit](https://github.com/rbalsleyMSFT/FFU/pull/24))
+- Some additional FFU size reduction enhancements (Thanks Zehadi Alam [Commit](https://github.com/rbalsleyMSFT/FFU/pull/25)):
   - Disk cleanup is now run before sysprep to help reduce FFU file size
   - Before FFU capture, Optimize-FFU is run to defrag and slabconsolidate the VHDX
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,12 @@ This process will copy Windows in about 2-3 minutes to the target device, option
 While we use this in Education at Microsoft, other industries can use it as well. We esepcially see a need for something like this with partners who do re-imaging on behalf of customers. The difference in Education is that they typically have large deployments that tend to happen at the beginning of the school year and any amount of time saved is helpful. Microsoft Deployment Toolkit, Configuration Manager, and other community solutions are all great solutions, but are typically slower due to WIM deployments being file-based while FFU files are sector-based.
 
 # Updates
+**2405.1**
+- Moved the resetbase command from within the VM to after servicing the VHDX. This will make it so the FFU size is smaller after the latest CU or .NET framework are installed. Thanks to Mike Kelly for the PR [Commit](https://github.com/rbalsleyMSFT/FFU/pull/24)
+- Some additional FFU size reduction enhancements (Thanks Zehadi Alam [Commit](https://github.com/rbalsleyMSFT/FFU/pull/25):
+-- Disk cleanup is now run before sysprep to help reduce FFU file size
+-- Before FFU capture, Optimize-FFU is run to defrag and slabconsolidate the VHDX
+
 
 **2404.3**
 - Fixed an issue where the latest Windows CU wasn't downloading properly [Commit](https://github.com/rbalsleyMSFT/FFU/commit/ae59183a199f39b310c79b31c9b4980fafdeb79b)


### PR DESCRIPTION
**2405.1**
- Moved the resetbase command from within the VM to after servicing the VHDX. This will make it so the FFU size is smaller after the latest CU or .NET framework are installed. (Thanks to Mike Kelly for the PR [Commit](https://github.com/rbalsleyMSFT/FFU/pull/24))
- Some additional FFU size reduction enhancements (Thanks Zehadi Alam [Commit](https://github.com/rbalsleyMSFT/FFU/pull/25)):
  - Disk cleanup is now run before sysprep to help reduce FFU file size
  - Before FFU capture, Optimize-FFU is run to defrag and slabconsolidate the VHDX