### PR TITLE
Automated Win32 and Store App Downloads and Installs

### DIFF
--- a/FFUDevelopment/Apps/AppsList.txt
+++ b/FFUDevelopment/Apps/AppsList.txt
@@ -1,0 +1,2 @@
+win32:7-Zip
+store:Company Portal

--- a/FFUDevelopment/BuildFFUVM.ps1
+++ b/FFUDevelopment/BuildFFUVM.ps1
@@ -3037,8 +3037,16 @@ function Get-FFUEnvironment {
         WriteLog "Removing $EdgePath"
         Remove-Item -Path $EdgePath -Recurse -Force
         WriteLog 'Removal complete'
-    }    
-
+    }
+    if (Test-Path -Path "$AppsPath\Win32" -PathType Container) {
+        WriteLog "Cleaning up Win32 folder"
+        Remove-Item -Path "$AppsPath\Win32" -Recurse -Force
+    }
+    if (Test-Path -Path "$AppsPath\MSStore" -PathType Container) {
+        WriteLog "Cleaning up MSStore folder"
+        Remove-Item -Path "$AppsPath\MSStore" -Recurse -Force
+    }   
+    Clear-InstallAppsandSysprep
     Writelog 'Removing dirty.txt file'
     Remove-Item -Path "$FFUDevelopmentPath\dirty.txt" -Force
     WriteLog "Cleanup complete"
@@ -3598,6 +3606,20 @@ try {
 catch {
     Write-Host 'Cleaning up InstallAppsandSysprep.cmd failed'
     Writelog "Cleaning up InstallAppsandSysprep.cmd failed with error $_"
+    throw $_
+}
+try {
+    if (Test-Path -Path "$AppsPath\Win32" -PathType Container) {
+        WriteLog "Cleaning up Win32 folder"
+        Remove-Item -Path "$AppsPath\Win32" -Recurse -Force
+    }
+    if (Test-Path -Path "$AppsPath\MSStore" -PathType Container) {
+        WriteLog "Cleaning up MSStore folder"
+        Remove-Item -Path "$AppsPath\MSStore" -Recurse -Force
+    }
+}
+catch {
+    WriteLog "$_"
     throw $_
 }
 #Create Deployment Media

--- a/FFUDevelopment/BuildFFUVM.ps1
+++ b/FFUDevelopment/BuildFFUVM.ps1
@@ -3050,6 +3050,12 @@ function Remove-FFU {
     WriteLog "Removal complete"
 }
 function Clear-InstallAppsandSysprep {
+    $cmdContent = Get-Content -Path "$AppsPath\InstallAppsandSysprep.cmd"
+    WriteLog "Updating $AppsPath\InstallAppsandSysprep.cmd to remove win32 app install commands"
+    $cmdContent -notmatch "D:\\win32*" | Set-Content -Path "$AppsPath\InstallAppsandSysprep.cmd"
+    $cmdContent = Get-Content -Path "$AppsPath\InstallAppsandSysprep.cmd"
+    WriteLog "Setting MSStore installation condition to false"
+    $cmdContent -replace 'set "INSTALL_STOREAPPS=true"', 'set "INSTALL_STOREAPPS=false"' | Set-Content -Path "$AppsPath\InstallAppsandSysprep.cmd"
     if ($UpdateLatestDefender) {
         WriteLog "Updating $AppsPath\InstallAppsandSysprep.cmd to remove Defender Platform Update"
         $CmdContent = Get-Content -Path "$AppsPath\InstallAppsandSysprep.cmd"

--- a/FFUDevelopment/BuildFFUVM.ps1
+++ b/FFUDevelopment/BuildFFUVM.ps1
@@ -1694,6 +1694,46 @@ function Install-WinGet {
         Remove-Item -Path $wingetPackageDestination -Force -ErrorAction SilentlyContinue
     }
 }
+
+function New-WinGetSettings {
+    $wingetSettingsFile = "$env:LOCALAPPDATA\Packages\Microsoft.DesktopAppInstaller_8wekyb3d8bbwe\LocalState\settings.json"
+    $wingetSettings = @(
+        '{'
+        '    "$schema": "https://aka.ms/winget-settings.schema.json",'
+        '    '
+        '    // For documentation on these settings, see: https://aka.ms/winget-settings'
+        '    "experimentalFeatures": {'
+        '        "storeDownload": true'
+        '    },'
+        '    "logging": {'
+        '        "level": "verbose"'
+        '    }'
+        '}'
+    )
+    $wingetSettingsContent = $wingetSettings -join "`n"
+    if (Test-Path -Path $wingetSettingsFile -PathType Leaf) {
+        $jsonContent = Get-Content -Path $wingetSettingsFile -Raw
+        # Check if storeDownload feature is already enabled
+        if ($jsonContent -notmatch '"storeDownload"\s*:\s*true') {
+            # Back up existing settings.json file
+            $backupWingetSettingsFile = $wingetSettingsFile + ".bak"
+            if (-not (Test-Path -Path $backupWingetSettingsFile -PathType Leaf)) {
+                WriteLog "Backing up existing WinGet settings.json file to $backupWingetSettingsFile"
+                Copy-Item -Path $wingetSettingsFile -Destination $backupWingetSettingsFile -Force | Out-Null
+            }
+            WriteLog "Creating WinGet settings.json file to allow the storeDownload feature. Writing file to $wingetSettingsFile"
+            $wingetSettingsContent | Out-File -FilePath $wingetSettingsFile -Encoding utf8 -Force
+        }
+        else {
+            WriteLog "WinGet's settings.json file is already configured to enable the storeDownload feature."
+        }
+    } 
+    else {
+        WriteLog "Creating WinGet settings.json file to allow the storeDownload feature. Writing file to $wingetSettingsFile"
+        $wingetSettingsContent | Out-File -FilePath $wingetSettingsFile -Encoding utf8 -Force
+    }
+}
+
 function Get-KBLink {
     param(
         [Parameter(Mandatory)]

--- a/FFUDevelopment/BuildFFUVM.ps1
+++ b/FFUDevelopment/BuildFFUVM.ps1
@@ -3206,7 +3206,7 @@ if ($InstallApps) {
             exit
         }
         WriteLog "$AppsPath\InstallAppsandSysprep.cmd found"
-        
+        Get-Apps -AppsList "$AppsPath\AppsList.txt"
         if (-not $InstallOffice) {
             #Modify InstallAppsandSysprep.cmd to REM out the office install command
             $CmdContent = Get-Content -Path "$AppsPath\InstallAppsandSysprep.cmd"


### PR DESCRIPTION
## Summary

This pull request provides an implementation of the features proposed in Issue [#30](https://github.com/rbalsleyMSFT/FFU/issues/30). It introduces functionality that leverages WinGet to automate the download of user-specified apps for inclusion in the FFU. The silent install commands for win32 apps are automatically added to the InstallAppsandSysprep.cmd file. Apps can be specified by the user in the AppsList.txt file under `C:\FFUDevelopment\Apps`. Win32 and Microsoft Store apps are supported for inclusion and must be distinguished by prefacing the app name with `win32:` or `store:`

**Example**
```txt
win32:7-Zip
store:Company Portal
```

To ensure that only a single result is received for the download to occur seamlessly, the `--exact` parameter is specified in WinGet’s `download` command for each app. Thus, app names must be specified exactly as their name is listed in the WinGet repository (case-sensitive). This is determined by typing in `winget search appname` and looking at the Name column to see how the app is listed.
```txt
PS C:\Windows\system32> winget search 7zip
Name              Id                     Version            Match         Source
--------------------------------------------------------------------------------
7-Zip             7zip.7zip              24.07              Moniker: 7zip winget
```

## Added Functions
### `Install-WinGet`
This function installs the latest preview version of WinGet, since the preview version supports an experimental feature that allows the download of Microsoft Store apps. 

### `New-WinGetSettings`
This function creates a settings.json file that enables the storeDownload feature if it is not already enabled.

### `Get-Win32App`
This function searches the WinGet repository for a user-specified win32 app from the AppsList.txt file and downloads it to `C:\FFUDevelopment\Apps\Win32\Appname`. The Win32 and Appname directories are created by the function. It then constructs the silent install command for each app by extracting the silent install switches from the yaml file that is downloaded along with the msi or exe. After constructing the silent install command, the command is appended to the InstallAppsandSysprep.cmd file

### `Get-StoreApp`
This function searches the WinGet repository for a user-specified msstore app from the AppsList.txt file and downloads it to `C:\FFUDevelopment\Apps\MSStore\Appname`. The MSStore and Appname directories are created by the function. Not all store app downloads are currently supported by WinGet. Some of the non-in-box apps that can be downloaded include Company Portal, Power BI Desktop, and Remote Desktop.

### `Get-Apps`
This function retrieves the content from the AppList.txt file and populates either a win32 or storeapps array with the names of the apps. It verifies the installation of the preview version of WinGet and installs it if necessary. It then invokes either the `Get-Win32App` or `Get-StoreApp` function based on the contents of the win32 or storeapps array.

## Other Additions
- The InstallAppsandSysprep.cmd file includes code to provision every app package under the `C:\FFUDevelopment\Apps\MSStore` directory, so that they will install for all new users. The execution of this code is controlled by the INSTALL_STOREAPPS flag, which is set to "false" by default. If store apps are specified in the AppsList.txt file and they can successfully download, then the flag will be set to "true" by the `Get-StoreApp` function.

- Added code to clean up the Win32 and MSStore directories after the script finishes or if the dirty.txt file is detected.

- Modified the `Clear-InstallAppsandSysprep` function to include code that removes the silent install commands for win32 apps downloaded by WinGet and sets the INSTALL_STOREAPPS flag to "false".

## Log
![log](https://github.com/rbalsleyMSFT/FFU/assets/63765084/f59ade00-3c0e-483d-8204-e4358bfc3228)