### PR TITLE
WinGet Download Architecture Handling

### DIFF
--- a/FFUDevelopment/BuildFFUVM.ps1
+++ b/FFUDevelopment/BuildFFUVM.ps1
@@ -1795,7 +1795,7 @@ function Get-StoreApp {
     WriteLog "Downloading $StoreApp and dependencies..."
     WriteLog 'MSStore app downloads require authentication with an Entra ID account. You may be prompted twice for credentials, once for the app and another for the license file.'
     $wingetDownloadResult = & winget.exe download --name --exact "$StoreApp" --download-directory "$appFolderPath" --accept-package-agreements --accept-source-agreements --source msstore --architecture "$WindowsArch" --scope machine | Out-String
-    # For some apps, specifiying the architecture leads to no results found for the app. In those cases, the command will be run without the architecture parameter.
+    # For some apps, specifying the architecture leads to no results found for the app. In those cases, the command will be run without the architecture parameter.
     if ($wingetDownloadResult -match "No applicable installer found") {
         $wingetDownloadResult = & winget.exe download --name --exact "$StoreApp" --download-directory "$appFolderPath" --accept-package-agreements --accept-source-agreements --source msstore --scope machine | Out-String
     }

--- a/FFUDevelopment/BuildFFUVM.ps1
+++ b/FFUDevelopment/BuildFFUVM.ps1
@@ -1795,6 +1795,10 @@ function Get-StoreApp {
     WriteLog "Downloading $StoreApp and dependencies..."
     WriteLog 'MSStore app downloads require authentication with an Entra ID account. You may be prompted twice for credentials, once for the app and another for the license file.'
     $wingetDownloadResult = & winget.exe download --name --exact "$StoreApp" --download-directory "$appFolderPath" --accept-package-agreements --accept-source-agreements --source msstore --architecture "$WindowsArch" --scope machine | Out-String
+    # For some apps, specifiying the architecture leads to no results found for the app. In those cases, the command will be run without the architecture parameter.
+    if ($wingetDownloadResult -match "No applicable installer found") {
+        $wingetDownloadResult = & winget.exe download --name --exact "$StoreApp" --download-directory "$appFolderPath" --accept-package-agreements --accept-source-agreements --source msstore --scope machine | Out-String
+    }
     # Many store apps can be found by winget search, but the download of the apps are unsupported.
     if ($wingetDownloadResult -match "No applicable Microsoft Store package download information found.") {
         WriteLog "No applicable Microsoft Store package download information found for $StoreApp. Skipping download."


### PR DESCRIPTION
Added condition to use `winget download` command without architecture parameter if specifying it leads to no app result.