### PR TITLE
Handle Win32 Apps of MSStore Type & Update InstallAppsandSysprep.cmd

### DIFF
--- a/FFUDevelopment/Apps/AppsList.txt
+++ b/FFUDevelopment/Apps/AppsList.txt
@@ -1,2 +1,2 @@
-win32:7-Zip
+winget:7-Zip
 store:Company Portal

--- a/FFUDevelopment/Apps/InstallAppsandSysprep.cmd
+++ b/FFUDevelopment/Apps/InstallAppsandSysprep.cmd
@@ -22,8 +22,15 @@ for /d %%D in ("%basepath%\*") do (
     set "dependenciesfolder=!appfolder!\Dependencies"
     for %%F in ("!appfolder!\*") do (
         if not "%%~dpF"=="!dependenciesfolder!\" (
-            set "mainpackage=%%F"
+            if /i not "%%~xF"==".xml" (
+                if /i not "%%~xF"==".yaml" (
+                    set "mainpackage=%%F"
+                )
+            ) 
         )
+    )
+    for %%F in ("!appfolder!\*.xml") do (
+        set "licensefile=%%F"
     )
     if defined mainpackage (
         if exist "!dependenciesfolder!" (
@@ -31,7 +38,12 @@ for /d %%D in ("%basepath%\*") do (
             for %%G in ("!dependenciesfolder!\*") do (
                 set "dism_command=!dism_command! /DependencyPackagePath:"%%G""
             )
-            set "dism_command=!dism_command! /SkipLicense /Region:All"
+            if defined licensefile (
+                set "dism_command=!dism_command! /LicensePath:"!licensefile!""
+            ) else (
+                set "dism_command=!dism_command! /SkipLicense"
+            )
+            set "dism_command=!dism_command! /Region:All"
             echo !dism_command!
             !dism_command!
         )


### PR DESCRIPTION
This PR addresses issues from PR [#33](https://github.com/rbalsleyMSFT/FFU/pull/33) with some additional enhancements.

* Added handling of win32 apps using the msstore source in `winget download` command.
* Moved out code from `Get-WinGetApp` to a separate function `Add-Win32SilentInstallCommand`. This is invoked in `Get-WinGetApp` and `Get-StoreApp` for win32 apps.
* Updated `win32:` prefix with `winget:` in AppsList.txt file.
* Updated function name `Get-Win32App` to `Get-WinGetApp` to reflect app source and AppList.txt prefix change.
* Updated InstallAppsandSysprep.cmd file
  - Filtered out .xml and .yaml files in app directory, so they are not included in DISM command
  - Included `/LicensePath` parameter in DISM command if store app license files are present. Otherwise `/SkipLicense` is used.
* Added miscellaneous code enhancements
  - Added `-ErrorAction` parameter to lines using `Get-ChildItem`
  - Trim leading and trailing spaces in AppsList.txt and silent install commands.