### PR TITLE
Improve WinGet Integration for Automated App Downloads and Installs

### DIFF
--- a/FFUDevelopment/Apps/AppList.json
+++ b/FFUDevelopment/Apps/AppList.json
@@ -9,6 +9,11 @@
             "name": "Company Portal",
             "id": "9WZDNCRFJ3PZ",
             "source": "msstore"
+        },
+        {
+            "name": "Microsoft Teams",
+            "id": "Microsoft.Teams",
+            "source": "winget"
         }
     ]
 }

--- a/FFUDevelopment/Apps/AppList.json
+++ b/FFUDevelopment/Apps/AppList.json
@@ -1,0 +1,14 @@
+{
+    "apps": [
+        {
+            "name": "7-Zip",
+            "id": "7zip.7zip",
+            "source": "winget"
+        },
+        {
+            "name": "Company Portal",
+            "id": "9WZDNCRFJ3PZ",
+            "source": "msstore"
+        }
+    ]
+}

--- a/FFUDevelopment/Apps/AppsList.txt
+++ b/FFUDevelopment/Apps/AppsList.txt
@@ -1,2 +1,0 @@
-winget:7-Zip
-store:Company Portal

--- a/FFUDevelopment/Apps/InstallAppsandSysprep.cmd
+++ b/FFUDevelopment/Apps/InstallAppsandSysprep.cmd
@@ -33,20 +33,20 @@ for /d %%D in ("%basepath%\*") do (
         set "licensefile=%%F"
     )
     if defined mainpackage (
+        set "dism_command=DISM /Online /Add-ProvisionedAppxPackage /PackagePath:"!mainpackage!""
         if exist "!dependenciesfolder!" (
-            set "dism_command=DISM /Online /Add-ProvisionedAppxPackage /PackagePath:"!mainpackage!""
             for %%G in ("!dependenciesfolder!\*") do (
                 set "dism_command=!dism_command! /DependencyPackagePath:"%%G""
             )
-            if defined licensefile (
-                set "dism_command=!dism_command! /LicensePath:"!licensefile!""
-            ) else (
-                set "dism_command=!dism_command! /SkipLicense"
-            )
-            set "dism_command=!dism_command! /Region:All"
-            echo !dism_command!
-            !dism_command!
         )
+        if defined licensefile (
+            set "dism_command=!dism_command! /LicensePath:"!licensefile!""
+        ) else (
+            set "dism_command=!dism_command! /SkipLicense"
+        )
+        set "dism_command=!dism_command! /Region:All"
+        echo !dism_command!
+        !dism_command!
     )
 )
 :remaining

--- a/FFUDevelopment/Apps/InstallAppsandSysprep.cmd
+++ b/FFUDevelopment/Apps/InstallAppsandSysprep.cmd
@@ -51,6 +51,11 @@ for /d %%D in ("%basepath%\*") do (
 )
 :remaining
 endlocal
+for /r "D:\" %%G in (.) do (
+    if exist "%%G\Notepad++" (
+        powershell -Command "Remove-AppxPackage -Package NotepadPlusPlus_1.0.0.0_neutral__7njy0v32s6xk6"
+    )
+)
 REM The below lines will remove the unattend.xml that gets the machine into audit mode. If not removed, the OS will get stuck booting to audit mode each time.
 REM Also kills the sysprep process in order to automate sysprep generalize
 del c:\windows\panther\unattend\unattend.xml /F /Q

--- a/FFUDevelopment/BuildFFUVM.ps1
+++ b/FFUDevelopment/BuildFFUVM.ps1
@@ -1811,18 +1811,14 @@ function Get-StoreApp {
         WriteLog "$StoreAppName not found in WinGet repository. Skipping download."
         return
     }
-    # Skip the header lines and get the line with the app information
-    $appResult = $wingetSearchResult | Select-Object -Skip 2 | Select-Object -First 1
-    # Split the line by whitespace and get the second-to-last item (the Id)
-    $appID = ($appResult -split '\s+')[-2]
-    # Checking app ID to determine if store app is a win32 app
     WriteLog "Checking if $StoreAppName is a win32 app..."
-    $appIsWin32 = $appID.StartsWith("XP")
+    $appIsWin32 = $StoreAppId.StartsWith("XP")
     if ($appIsWin32) {
         WriteLog "$StoreAppName is a win32 app. Adding to $AppsPath\win32 folder"
         $appFolderPath = Join-Path -Path "$AppsPath\win32" -ChildPath $StoreAppName
     }
     else {
+        WriteLog "$StoreAppName is not a win32 app."
         $appFolderPath = Join-Path -Path "$AppsPath\MSStore" -ChildPath $StoreAppName
     }
     New-Item -Path $appFolderPath -ItemType Directory -Force | Out-Null

--- a/FFUDevelopment/BuildFFUVM.ps1
+++ b/FFUDevelopment/BuildFFUVM.ps1
@@ -1890,9 +1890,9 @@ function Get-StoreApp {
 
 function Get-Apps {
     param (
-        [string]$AppsList
+        [string]$AppList
     )
-    $apps = Get-Content -Path $AppsList -Raw | ConvertFrom-Json
+    $apps = Get-Content -Path $AppList -Raw | ConvertFrom-Json
     if (-not $apps) {
         WriteLog "No apps were specified in AppList.json file."
         return
@@ -3349,7 +3349,7 @@ if ($InstallApps) {
             exit
         }
         WriteLog "$AppsPath\InstallAppsandSysprep.cmd found"
-        Get-Apps -AppsList "$AppsPath\AppList.json"
+        Get-Apps -AppList "$AppsPath\AppList.json"
         if (-not $InstallOffice) {
             #Modify InstallAppsandSysprep.cmd to REM out the office install command
             $CmdContent = Get-Content -Path "$AppsPath\InstallAppsandSysprep.cmd"

--- a/FFUDevelopment/BuildFFUVM.ps1
+++ b/FFUDevelopment/BuildFFUVM.ps1
@@ -1700,42 +1700,6 @@ function Confirm-WinGetInstallation {
     }
 }
 
-function New-WinGetSettings {
-    $wingetSettingsFile = "$env:LOCALAPPDATA\Packages\Microsoft.DesktopAppInstaller_8wekyb3d8bbwe\LocalState\settings.json"
-    $wingetSettings = @(
-        '{'
-        '    "$schema": "https://aka.ms/winget-settings.schema.json",'
-        '    '
-        '    // For documentation on these settings, see: https://aka.ms/winget-settings'
-        '    "experimentalFeatures": {'
-        '        "storeDownload": true'
-        '    },'
-        '    "logging": {'
-        '        "level": "verbose"'
-        '    }'
-        '}'
-    )
-    $wingetSettingsContent = $wingetSettings -join "`n"
-    if (Test-Path -Path $wingetSettingsFile -PathType Leaf) {
-        $jsonContent = Get-Content -Path $wingetSettingsFile -Raw
-        # Check if storeDownload feature is already enabled
-        WriteLog "Checking if storeDownload feature is enabled in WinGet configuration."
-        if ($jsonContent -match '"storeDownload"\s*:\s*true') {
-            WriteLog "WinGet's settings.json file is already configured to enable the storeDownload feature."
-            return
-        }
-        # Back up existing settings.json file
-        WriteLog "The storeDownload feature is not enabled in WinGet configuration."
-        $backupWingetSettingsFile = $wingetSettingsFile + ".bak"
-        if (-not (Test-Path -Path $backupWingetSettingsFile -PathType Leaf)) {
-            WriteLog "Backing up existing WinGet settings.json file to $backupWingetSettingsFile"
-            Copy-Item -Path $wingetSettingsFile -Destination $backupWingetSettingsFile -Force | Out-Null
-        }
-    } 
-    WriteLog "Creating WinGet settings.json file to allow the storeDownload feature. Writing file to $wingetSettingsFile"
-    $wingetSettingsContent | Out-File -FilePath $wingetSettingsFile -Encoding utf8 -Force
-}
-
 function Add-Win32SilentInstallCommand {
     param (
         [string]$AppFolder,
@@ -1962,7 +1926,6 @@ function Get-Apps {
         }
     }
     if ($storeApps) {
-        New-WinGetSettings
         if (-not (Test-Path -Path $storeAppsFolder -PathType Container)) {
             New-Item -Path $storeAppsFolder -ItemType Directory -Force | Out-Null
         }


### PR DESCRIPTION
This PR improves the WinGet integration and overall app download and installation process.

- Converted `AppsList.txt` to a JSON file for more reliable WinGet searches. More details in #34 
- Refactored all introduced functions in #32 for greater maintainability, readability, and efficiency.
- Updated `InstallAppsandSysprep.cmd` to support installing packages without dependencies (supports new Teams) and handle issues with Notepad++. An unprovisioned package gets installed with Notepad++, which causes Sysprep to fail. This package is removed if Notepad++ is included as an app to be installed.
- Organized code into distinct functions: `Confirm-WinGetInstallation` `Set-InstallStoreAppsFlag`
- Added `Architecture` parameter to `Install-WinGet` function and modified it to download the latest stable release of WinGet.
- Removed the `New-WinGetSettings` function, as the latest stable WinGet version natively supports downloading MSStore apps.

Attaching my `AppList.json` file with a variety of different apps for testing on ARM device.
[AppList.json](https://github.com/user-attachments/files/16200909/AppList.json)
