### PR TITLE
Fix for Missing Windows Boot Manager Entry

### DIFF
--- a/FFUDevelopment/WinPEDeployFFUFiles/ApplyFFU.ps1
+++ b/FFUDevelopment/WinPEDeployFFUFiles/ApplyFFU.ps1
@@ -554,6 +554,12 @@ If (Test-Path -Path $Drivers)
     WriteLog 'Copying drivers succeeded'
 }
 
+WriteLog "Setting Windows Boot Manager to be first in the display order."
+Invoke-Process bcdedit.exe "/set {fwbootmgr} displayorder {bootmgr} /addfirst"
+WriteLog "Windows Boot Manager has been set to be first in the display order."
+WriteLog "Setting default Windows boot loader to be first in the display order."
+Invoke-Process bcdedit.exe "/set {bootmgr} displayorder {default} /addfirst"
+WriteLog "The default Windows boot loader has been set to be first in the display order."
 #Copy DISM log to USBDrive
 WriteLog "Copying dism log to $USBDrive"
 invoke-process xcopy "X:\Windows\logs\dism\dism.log $USBDrive /Y" 


### PR DESCRIPTION
When Dell devices have their SATA/NVMe operation switched from RAID to AHCI/NVMe mode in the BIOS and are then imaged, Windows Boot Manager does not appear in the boot menu. This causes the computer to enter network boot, which has a higher boot priority than the SSD on recent models. To resolve this, the following commands are run before the device exits WinPE:

`bcdedit /set {fwbootmgr} displayorder {bootmgr} /addfirst`
`bcdedit /set {bootmgr} displayorder {default} /addfirst`

https://learn.microsoft.com/en-us/windows-hardware/manufacture/desktop/bcd-system-store-settings-for-uefi?view=windows-11#other-settings