### PR TITLE
Time To Complete Shows Hours if Needed

### DIFF
--- a/FFUDevelopment/BuildFFUVM.ps1
+++ b/FFUDevelopment/BuildFFUVM.ps1
@@ -4349,8 +4349,12 @@ Write-Host "FFU build process completed at" $endTime
 # Calculate the total run time
 $runTime = $endTime - $startTime
 
-# Format the runtime as minutes and seconds
-$runTimeFormatted = 'Duration: {0:mm} min {0:ss} sec' -f $runTime
+# Format the runtime with hours, minutes, and seconds
+if ($runTime.TotalHours -ge 1) {
+    $runTimeFormatted = 'Duration: {0:hh} hr {0:mm} min {0:ss} sec' -f $runTime
+} else {
+    $runTimeFormatted = 'Duration: {0:mm} min {0:ss} sec' -f $runTime
+}
 
 if ($VerbosePreference -ne 'Continue'){
     Write-Host $runTimeFormatted


### PR DESCRIPTION
Depending on the install size of selected Updates and large applications installers like Autodesk or Adobe, FFU builds can take more than an hour. The display then rolls over the minutes and looks a little strange.

- Add Hours, Minutes and Seconds to Total Time to Complete if total time has gone over 1 hour. Else only shows the minutes and seconds.