### PR TITLE
Add support for Windows Server

### DIFF
--- a/FFUDevelopment/BuildFFUVM.ps1
+++ b/FFUDevelopment/BuildFFUVM.ps1
@@ -4233,7 +4233,15 @@ try {
     #The Windows release info page is updated later than the MU Catalog
     if ($UpdateLatestCU -and -not $UpdatePreviewCU) {
         Writelog "`$UpdateLatestCU is set to true, checking for latest CU"
-        $Name = """Cumulative update for Windows $WindowsRelease Version $WindowsVersion for $WindowsArch"""
+        if ($WindowsRelease -le 11) {
+            $Name = """Cumulative update for Windows $WindowsRelease Version $WindowsVersion for $WindowsArch"""
+        } elseif ($WindowsRelease -eq 2022) {
+            $Name = """Cumulative Update for Microsoft server operating system, version $WindowsVersion for $WindowsArch"""
+        } elseif ($WindowsRelease -lt 2022) {
+            $Name = """Cumulative update for Windows 10 Version $WindowsVersion for $WindowsArch"""
+        } else {
+            $Name = """Cumulative update for Windows 11 Version $WindowsVersion for $WindowsArch"""
+        }
         #Check if $KBPath exists, if not, create it
         If (-not (Test-Path -Path $KBPath)) {
             WriteLog "Creating $KBPath"
@@ -4248,7 +4256,15 @@ try {
     #will take Precendence over $UpdateLastestCU if both were set to $true
     if ($UpdatePreviewCU) {
         Writelog "`$UpdatePreviewCU is set to true, checking for latest Preview CU"
-        $Name = """Cumulative update Preview for Windows $WindowsRelease Version $WindowsVersion for $WindowsArch"""
+	if ($WindowsRelease -le 11) {
+            $Name = """Cumulative update Preview for Windows $WindowsRelease Version $WindowsVersion for $WindowsArch"""
+        } elseif ($WindowsRelease -eq 2022) {
+            $Name = """Cumulative Update Preview for Microsoft server operating system, version $WindowsVersion for $WindowsArch"""
+        } elseif ($WindowsRelease -lt 2022) {
+            $Name = """Cumulative update Preview for Windows 10 Version $WindowsVersion for $WindowsArch"""
+        } else {
+            $Name = """Cumulative update Preview for Windows 11 Version $WindowsVersion for $WindowsArch"""
+        }
         #Check if $KBPath exists, if not, create it
         If (-not (Test-Path -Path $KBPath)) {
             WriteLog "Creating $KBPath"

--- a/FFUDevelopment/BuildFFUVM.ps1
+++ b/FFUDevelopment/BuildFFUVM.ps1
@@ -201,7 +201,11 @@ param(
     [Parameter(Mandatory = $false, Position = 0)]
     [ValidateScript({ Test-Path $_ })]
     [string]$ISOPath,
-    [ValidateSet('Home', 'Home N', 'Home Single Language', 'Education', 'Education N', 'Pro', 'Pro N', 'Pro Education', 'Pro Education N', 'Pro for Workstations', 'Pro N for Workstations', 'Enterprise', 'Enterprise N')]
+    [ValidateScript({
+            $allowedSKUs = @('Home', 'Home N', 'Home Single Language', 'Education', 'Education N', 'Pro', 'Pro N', 'Pro Education', 'Pro Education N', 'Pro for Workstations', 'Pro N for Workstations', 'Enterprise', 'Enterprise N', 'Standard', 'Standard (Desktop Experience)', 'Datacenter', 'Datacenter (Desktop Experience)')
+            if ($allowedSKUs -contains $_) { $true } else { throw "Invalid WindowsSKU value. Allowed values: $($allowedSKUs -join ', ')" }
+            return $true
+        })]
     [string]$WindowsSKU = 'Pro',
     [ValidateScript({ Test-Path $_ })]
     [string]$FFUDevelopmentPath = $PSScriptRoot,
@@ -267,7 +271,7 @@ param(
     [string]$ProductKey,
     [bool]$BuildUSBDrive,
     [Parameter(Mandatory = $false)]
-    [ValidateSet(10, 11)]
+    [ValidateSet(10, 11, 2016, 2019, 2022, 2025)]
     [int]$WindowsRelease = 11,
     [Parameter(Mandatory = $false)]
     [string]$WindowsVersion = '23h2',

--- a/FFUDevelopment/BuildFFUVM.ps1
+++ b/FFUDevelopment/BuildFFUVM.ps1
@@ -3265,14 +3265,25 @@ Function Get-WindowsVersionInfo {
         Enterprise { 'Ent' }
         Education { 'Edu' }
         ProfessionalWorkstation { 'Pro_Wks' }
+	ServerStandard { 'Srv_Std' }
+        ServerDatacenter { 'Srv_Dtc' }
     }
     WriteLog "Windows SKU Modified to: $SKU"
 
-    if ($CurrentBuild -ge 22000) {
-        $Name = 'Win11'
-    }
-    else {
-        $Name = 'Win10'
+    if ($SKU -notmatch "Srv") {
+        if ($CurrentBuild -ge 22000) {
+            $Name = 'Win11'
+        }
+        else {
+            $Name = 'Win10'
+        }
+    } else {
+        $Name = switch ($CurrentBuild) {
+            26100 { '2025' }
+            20348 { '2022' }
+            17763 { '2019' }
+            Default { $DisplayVersion }
+        }
     }
     
     WriteLog "Unloading registry"

--- a/FFUDevelopment/BuildFFUVM.ps1
+++ b/FFUDevelopment/BuildFFUVM.ps1
@@ -1767,8 +1767,10 @@ function Get-WindowsESD {
     $cabFileUrl = if ($WindowsRelease -eq 10) {
         'https://go.microsoft.com/fwlink/?LinkId=841361'
     }
-    else {
+    elseif ($WindowsRelease -eq 11) {
         'https://go.microsoft.com/fwlink/?LinkId=2156292'
+    } else {
+        throw "Can't download Windows Server. Please download the Windows setup media from your subscription homepage."
     }
 
     # Download cab file

--- a/FFUDevelopment/BuildFFUVM.ps1
+++ b/FFUDevelopment/BuildFFUVM.ps1
@@ -2414,16 +2414,21 @@ function Get-KBLink {
 }
 function Get-LatestWindowsKB {
     param (
-        [ValidateSet(10, 11)]
-        [int]$WindowsRelease
+        [Parameter(Mandatory)]
+        [ValidateSet(10, 11, 2016, 2019, 2022, 2025)]
+        [int]$WindowsRelease,
+        [Parameter(Mandatory)]
+        [string]$WindowsVersion
     )
         
     # Define the URL of the update history page based on the Windows release
     if ($WindowsRelease -eq 11) {
         $updateHistoryUrl = 'https://learn.microsoft.com/en-us/windows/release-health/windows11-release-information'
     }
-    else {
+    elseif ($WindowsRelease -eq 10) {
         $updateHistoryUrl = 'https://learn.microsoft.com/en-us/windows/release-health/release-information'
+    } else {
+        $updateHistoryUrl = 'https://learn.microsoft.com/en-us/windows/release-health/windows-server-release-info'
     }
         
     # Use Invoke-WebRequest to fetch the content of the page
@@ -2433,7 +2438,11 @@ function Get-LatestWindowsKB {
     $VerbosePreference = $OriginalVerbosePreference
         
     # Use a regular expression to find the KB article number
-    $kbArticleRegex = 'KB\d+'
+    if ($WindowsRelease -le 11) {
+        $kbArticleRegex = "(?:Version $WindowsRelease \(OS build d+\)(?!(KB)).)*?KB\d+"
+    } else {
+        $kbArticleRegex = "(?:Windows Server $WindowsRelease \(OS build d+\)(?!(KB)).)*?KB\d+"
+    }
     $kbArticle = [regex]::Match($response.Content, $kbArticleRegex).Value
         
     return $kbArticle

--- a/FFUDevelopment/BuildFFUVM.ps1
+++ b/FFUDevelopment/BuildFFUVM.ps1
@@ -2737,7 +2737,7 @@ function New-OSPartition {
     if ((Get-CimInstance Win32_OperatingSystem).Caption -match "Server") {
         WriteLog (Expand-WindowsImage -ImagePath $WimPath -Index $WimIndex -ApplyPath "$($osPartition.DriveLetter):\")
     }
-    if ($CompactOS) {
+    elseif ($CompactOS) {
         WriteLog '$CompactOS is set to true, using -Compact switch to apply the WIM file to the OS partition.'
         WriteLog (Expand-WindowsImage -ImagePath $WimPath -Index $WimIndex -ApplyPath "$($osPartition.DriveLetter):\" -Compact)
     }

--- a/FFUDevelopment/BuildFFUVM.ps1
+++ b/FFUDevelopment/BuildFFUVM.ps1
@@ -2600,8 +2600,13 @@ function Get-Index {
     
     # Get the ImageName of ImageIndex 1 if an ISO was specified, else use ImageIndex 4 - this is usually Home or Education SKU on ESD MCT media
     if($ISOPath){
-        $imageIndex = $imageIndexes | Where-Object ImageIndex -eq 1
-        $WindowsImage = $imageIndex.ImageName.Substring(0, 10)
+        if ($WindowsSKU -notmatch "Standard|Datacenter") {
+            $imageIndex = $imageIndexes | Where-Object ImageIndex -eq 1
+            $WindowsImage = $imageIndex.ImageName.Substring(0, 10)
+        } else {
+            $imageIndex = $imageIndexes | Where-Object ImageIndex -eq 1
+            $WindowsImage = $imageIndex.ImageName.Substring(0, 19)
+        }
     }
     else{
         $imageIndex = $imageIndexes | Where-Object ImageIndex -eq 4
@@ -2619,8 +2624,8 @@ function Get-Index {
         return $matchingImageIndex.ImageIndex
     }
     else {
-        # Look for either the number 10 or 11 in the ImageName
-        $relevantImageIndexes = $imageIndexes | Where-Object { ($_.ImageName -like "*10*") -or ($_.ImageName -like "*11*") }
+        # Look for the numbers 10, 11, 2016, 2019, 2022+ in the ImageName
+        $relevantImageIndexes = $imageIndexes | Where-Object { ($_.ImageName -match "(10|11|2016|2019|202\d)") }
             
         while ($true) {
             # Present list of ImageNames to the end user if no matching ImageIndex is found

--- a/FFUDevelopment/BuildFFUVM.ps1
+++ b/FFUDevelopment/BuildFFUVM.ps1
@@ -4278,7 +4278,13 @@ try {
     #Update Latest .NET Framework
     if ($UpdateLatestNet) {
         Writelog "`$UpdateLatestNet is set to true, checking for latest .NET Framework"
-        $Name = "Cumulative update for .net framework windows $WindowsRelease $WindowsVersion $WindowsArch -preview"
+        if ($WindowsRelease -le 11) {
+            $Name = "Cumulative update for .net framework windows $WindowsRelease $WindowsVersion $WindowsArch -preview"
+        } elseif ($WindowsRelease -le 2022) {
+            $Name = "Cumulative update for .net framework windows 10 $WindowsVersion for $WindowsArch -preview"
+        } else {
+            $Name = "Cumulative update for .net framework windows 11 $WindowsVersion for $WindowsArch -preview"
+        }
         #Check if $KBPath exists, if not, create it
         If (-not (Test-Path -Path $KBPath)) {
             WriteLog "Creating $KBPath"

--- a/FFUDevelopment/BuildFFUVM.ps1
+++ b/FFUDevelopment/BuildFFUVM.ps1
@@ -2563,9 +2563,13 @@ function Get-WimIndex {
     If ($ISOPath) {
         $wimindex = switch ($WindowsSKU) {
             'Home' { 1 }
+            'Standard' { 1 }
             'Home_N' { 2 }
+            'Standard (Desktop Experience)' { 1 }
             'Home_SL' { 3 }
+            'Datacenter' { 3 }
             'EDU' { 4 }
+            'Datacenter (Desktop Experience)' { 4 }
             'EDU_N' { 5 }
             'Pro' { 6 }
             'Pro_N' { 7 }

--- a/FFUDevelopment/WinPECaptureFFUFiles/CaptureFFU.ps1
+++ b/FFUDevelopment/WinPECaptureFFUFiles/CaptureFFU.ps1
@@ -28,13 +28,24 @@ $SKU = switch ($SKU) {
     EducationN { 'EduN'}
     ProfessionalWorkstation { 'Pro_Wks' }
     ProfessionalWorkstationN { 'Pro_WksN' }
+    ServerStandard { 'Srv_Std' }
+    ServerDatacenter { 'Srv_Dtc' }
 }
 
-if($CurrentBuild -ge 22000){
-    $Name = 'Win11'
-}
-else{
-    $Name = 'Win10'
+if ($SKU -notmatch "Srv") {
+    if ($CurrentBuild -ge 22000) {
+        $Name = 'Win11'
+    }
+    else {
+        $Name = 'Win10'
+    }
+} else {
+    $Name = switch ($CurrentBuild) {
+        26100 { '2025' }
+        20348 { '2022' }
+        17763 { '2019' }
+        Default { $DisplayVersion }
+    }
 }
 
 #If Office is installed, modify the file name of the FFU


### PR DESCRIPTION
The current workflow is very convenient for Windows clients OS deployments but can't process Windows Server images.
This pull request adds support for Windows Server 2022 and Windows Server 2025 deployments.

The scripts also tries to process Windows Server 2019 and Windows Server 2016 partially, but this hasn't been tested so far.

As far as I know there isn't an official download link for Windows Server downloads so testing was done with a downloaded ISO only and the script function updated to throw when a download is attempted.

There might be an issue with outdated ISOs since missing the most recent SSU (servicing stack update) will probably cause the msu (update file) install to fail. This will probably require addressing once Windows checkpoint updates will become a thing.
A suggested fix for that would be to first detect the most recent SSU/checkpoint update, then installing it, dismounting and re-mounting the wim-file.