### PR TITLE
2410.1 Custom FFU names

### DIFF
--- a/FFUDevelopment/Apps/InstallAppsandSysprep.cmd
+++ b/FFUDevelopment/Apps/InstallAppsandSysprep.cmd
@@ -9,6 +9,8 @@ REM Install Windows Malicious Software Removal Tool
 REM Install OneDrive Per Machine
 REM Install Edge Stable
 REM Winget Win32 Apps
+REM START Batch variables placeholder
+REM END Batch variables placeholder
 REM Add additional apps below here
 REM Contoso App (Example)
 REM msiexec /i d:\Contoso\setup.msi /qn /norestart

--- a/FFUDevelopment/BuildFFUVM.ps1
+++ b/FFUDevelopment/BuildFFUVM.ps1
@@ -2729,7 +2729,7 @@ Function Set-CaptureFFU {
 	WriteLog 'Updating share command in CaptureFFU.ps1 script with new share information'
         $UpdatedContent = $ScriptContent -replace '^\$CustomFFUNameTemplate \= .*#Custom naming', "#Custom naming placeholder"
 	if (![string]::IsNullOrEmpty($CustomFFUNameTemplate)) {
-            $UpdatedContent = $ScriptContent -replace '#Custom naming placeholder', ("`$CustomFFUNameTemplate = '$CustomFFUNameTemplate'")
+            $UpdatedContent = $ScriptContent -replace '#Custom naming placeholder', ("`$CustomFFUNameTemplate = '$CustomFFUNameTemplate' #Custom naming")
 	    WriteLog 'Updating share command in CaptureFFU.ps1 script with new ffu name template information'
         }
         Set-Content -Path $CaptureFFUScriptPath -Value $UpdatedContent

--- a/FFUDevelopment/BuildFFUVM.ps1
+++ b/FFUDevelopment/BuildFFUVM.ps1
@@ -2727,8 +2727,9 @@ Function Set-CaptureFFU {
         $ScriptContent = Get-Content -Path $CaptureFFUScriptPath
         $UpdatedContent = $ScriptContent -replace '(net use).*', ("$SharePath")
 	WriteLog 'Updating share command in CaptureFFU.ps1 script with new share information'
+        $UpdatedContent = $ScriptContent -replace '^\$CustomFFUNameTemplate \= .*#Custom naming', "#Custom naming placeholder"
 	if (![string]::IsNullOrEmpty($CustomFFUNameTemplate)) {
-            $UpdatedContent = $ScriptContent -replace '#Custom naming placeholder', ("`$CustomFFUNameTemplate = $CustomFFUNameTemplate")
+            $UpdatedContent = $ScriptContent -replace '#Custom naming placeholder', ("`$CustomFFUNameTemplate = '$CustomFFUNameTemplate'")
 	    WriteLog 'Updating share command in CaptureFFU.ps1 script with new ffu name template information'
         }
         Set-Content -Path $CaptureFFUScriptPath -Value $UpdatedContent

--- a/FFUDevelopment/BuildFFUVM.ps1
+++ b/FFUDevelopment/BuildFFUVM.ps1
@@ -2727,9 +2727,9 @@ Function Set-CaptureFFU {
         $ScriptContent = Get-Content -Path $CaptureFFUScriptPath
         $UpdatedContent = $ScriptContent -replace '(net use).*', ("$SharePath")
 	WriteLog 'Updating share command in CaptureFFU.ps1 script with new share information'
-        $UpdatedContent = $ScriptContent -replace '^\$CustomFFUNameTemplate \= .*#Custom naming', "#Custom naming placeholder"
+        $UpdatedContent = $UpdatedContent -replace '^\$CustomFFUNameTemplate \= .*#Custom naming', "#Custom naming placeholder"
 	if (![string]::IsNullOrEmpty($CustomFFUNameTemplate)) {
-            $UpdatedContent = $ScriptContent -replace '#Custom naming placeholder', ("`$CustomFFUNameTemplate = '$CustomFFUNameTemplate' #Custom naming")
+            $UpdatedContent = $UpdatedContent -replace '#Custom naming placeholder', ("`$CustomFFUNameTemplate = '$CustomFFUNameTemplate' #Custom naming")
 	    WriteLog 'Updating share command in CaptureFFU.ps1 script with new ffu name template information'
         }
         Set-Content -Path $CaptureFFUScriptPath -Value $UpdatedContent

--- a/FFUDevelopment/WinPECaptureFFUFiles/CaptureFFU.ps1
+++ b/FFUDevelopment/WinPECaptureFFUFiles/CaptureFFU.ps1
@@ -13,6 +13,7 @@ reg load "HKLM\FFU" $Software
 $SKU = Get-ItemPropertyValue -Path 'HKLM:\FFU\Microsoft\Windows NT\CurrentVersion\' -Name 'EditionID'
 [int]$CurrentBuild = Get-ItemPropertyValue -Path 'HKLM:\FFU\Microsoft\Windows NT\CurrentVersion\' -Name 'CurrentBuild'
 $DisplayVersion = Get-ItemPropertyValue -Path 'HKLM:\FFU\Microsoft\Windows NT\CurrentVersion\' -Name 'DisplayVersion'
+$InstallationType = Get-ItemPropertyValue -Path 'HKLM:\FFU\Microsoft\Windows NT\CurrentVersion\' -Name 'InstallationType'
 $BuildDate = Get-Date -uformat %b%Y
 
 $SKU = switch ($SKU) {
@@ -29,13 +30,27 @@ $SKU = switch ($SKU) {
     EducationN { 'EduN'}
     ProfessionalWorkstation { 'Pro_Wks' }
     ProfessionalWorkstationN { 'Pro_WksN' }
+    ServerStandard { 'Srv_Std' }
+    ServerDatacenter { 'Srv_Dtc' }
 }
 
-if($CurrentBuild -ge 22000){
-    $Name = 'Win11'
-}
-else{
-    $Name = 'Win10'
+if ($InstallationType -eq "Client") {
+    if ($CurrentBuild -ge 22000) {
+        $Name = 'Win11'
+    }
+    else {
+        $Name = 'Win10'
+    }
+} else {
+    $Name = switch ($CurrentBuild) {
+        26100 { '2025' }
+        20348 { '2022' }
+        17763 { '2019' }
+        Default { $DisplayVersion }
+    }
+    if ($InstallationType -eq "Server Core") {
+        $SKU += "_Core"
+    }
 }
 
 #If Office is installed, modify the file name of the FFU

--- a/FFUDevelopment/WinPECaptureFFUFiles/CaptureFFU.ps1
+++ b/FFUDevelopment/WinPECaptureFFUFiles/CaptureFFU.ps1
@@ -1,5 +1,6 @@
 #Modify the net use W: \\192.168.1.158\FFUCaptureShare /user:ffu_user ddb1f077-3eed-433c-b4d9-7b8cd54ce727
 net use W: \\192.168.1.158\FFUCaptureShare /user:ffu_user ddb1f077-3eed-433c-b4d9-7b8cd54ce727
+#Custom naming placeholder
 
 $AssignDriveLetter = 'x:\AssignDriveLetter.txt'
 Start-Process -FilePath diskpart.exe -ArgumentList "/S $AssignDriveLetter" -Wait -ErrorAction Stop | Out-Null
@@ -40,16 +41,31 @@ else{
 #If Office is installed, modify the file name of the FFU
 #$Office = Get-childitem -Path 'M:\Program Files\Microsoft Office' -ErrorAction SilentlyContinue | Out-Null
 $Office = Get-childitem -Path 'M:\Program Files\Microsoft Office' -ErrorAction SilentlyContinue
-if($Office){
+if ($Office) {
     $ffuFilePath = "W:\$Name`_$DisplayVersion`_$SKU`_Office`_$BuildDate.ffu"
-    $dismArgs = "/capture-ffu /imagefile=$ffuFilePath /capturedrive=\\.\PhysicalDrive0 /name:$Name$DisplayVersion$SKU /Compress:Default"
-    
-    
-}
-else{
+} else {
     $ffuFilePath = "W:\$Name`_$DisplayVersion`_$SKU`_Apps`_$BuildDate.ffu"
-    $dismArgs = "/capture-ffu /imagefile=$ffuFilePath /capturedrive=\\.\PhysicalDrive0 /name:$Name$DisplayVersion$SKU /Compress:Default"
-    
+}
+$dismArgs = "/capture-ffu /imagefile=$ffuFilePath /capturedrive=\\.\PhysicalDrive0 /name:$Name$DisplayVersion$SKU /Compress:Default"
+
+if (![string]::IsNullOrEmpty($CustomFFUNameTemplate)) {
+    $CustomFFUNameTemplate = $CustomFFUNameTemplate -replace "{Name}", $Name
+    $CustomFFUNameTemplate = $CustomFFUNameTemplate -replace "{DisplayVersion}", $DisplayVersion
+    $CustomFFUNameTemplate = $CustomFFUNameTemplate -replace "{SKU}", $SKU
+    $CustomFFUNameTemplate = $CustomFFUNameTemplate -replace "{BuildDate}", $BuildDate
+    $CustomFFUNameTemplate = $CustomFFUNameTemplate -replace "{yyyy}", (Get-Date -UFormat "%Y")
+    $CustomFFUNameTemplate = $CustomFFUNameTemplate -replace "{MM}", (Get-Date -UFormat "%m")
+    $CustomFFUNameTemplate = $CustomFFUNameTemplate -replace "{dd}", (Get-Date -UFormat "%d")
+    $CustomFFUNameTemplate = $CustomFFUNameTemplate -replace "{H}", (Get-Date -UFormat "%H")
+    $CustomFFUNameTemplate = $CustomFFUNameTemplate -replace "{hh}", (Get-Date -UFormat "%I")
+    $CustomFFUNameTemplate = $CustomFFUNameTemplate -replace "{mm}", (Get-Date -UFormat "%M")
+    $CustomFFUNameTemplate = $CustomFFUNameTemplate -replace "{tt}", (Get-Date -UFormat "%p")
+
+    if (!$CustomFFUNameTemplate.EndsWith(".ffu")) {
+        $CustomFFUNameTemplate += ".ffu"
+    }
+
+    $dismArgs = "/capture-ffu /imagefile=$CustomFFUNameTemplate /capturedrive=\\.\PhysicalDrive0 /name:$Name$DisplayVersion$SKU /Compress:Default"
 }
 
 #Unload Registry

--- a/FFUDevelopment/WinPECaptureFFUFiles/CaptureFFU.ps1
+++ b/FFUDevelopment/WinPECaptureFFUFiles/CaptureFFU.ps1
@@ -65,7 +65,7 @@ if (![string]::IsNullOrEmpty($CustomFFUNameTemplate)) {
         $CustomFFUNameTemplate += ".ffu"
     }
 
-    $dismArgs = "/capture-ffu /imagefile=$CustomFFUNameTemplate /capturedrive=\\.\PhysicalDrive0 /name:$Name$DisplayVersion$SKU /Compress:Default"
+    $dismArgs = "/capture-ffu /imagefile=W:\$CustomFFUNameTemplate /capturedrive=\\.\PhysicalDrive0 /name:$Name$DisplayVersion$SKU /Compress:Default"
 }
 
 #Unload Registry

--- a/FFUDevelopment/WinPECaptureFFUFiles/CaptureFFU.ps1
+++ b/FFUDevelopment/WinPECaptureFFUFiles/CaptureFFU.ps1
@@ -56,7 +56,7 @@ if (![string]::IsNullOrEmpty($CustomFFUNameTemplate)) {
     $CustomFFUNameTemplate = $CustomFFUNameTemplate -replace "{yyyy}", (Get-Date -UFormat "%Y")
     $CustomFFUNameTemplate = $CustomFFUNameTemplate -replace "{MM}", (Get-Date -UFormat "%m")
     $CustomFFUNameTemplate = $CustomFFUNameTemplate -replace "{dd}", (Get-Date -UFormat "%d")
-    $CustomFFUNameTemplate = $CustomFFUNameTemplate -replace "{H}", (Get-Date -UFormat "%H")
+    $CustomFFUNameTemplate = $CustomFFUNameTemplate -replace "{HH}", (Get-Date -UFormat "%H")
     $CustomFFUNameTemplate = $CustomFFUNameTemplate -replace "{hh}", (Get-Date -UFormat "%I")
     $CustomFFUNameTemplate = $CustomFFUNameTemplate -replace "{mm}", (Get-Date -UFormat "%M")
     $CustomFFUNameTemplate = $CustomFFUNameTemplate -replace "{tt}", (Get-Date -UFormat "%p")


### PR DESCRIPTION
Add the parameter CustomFFUNameTemplate that allows to set a custom name for the output FFU file.

Implemented placeholders are:
- {Name}
- {DisplayVersion}
- {SKU}
- {BuildDate}
- {yyyy}
- {MM}
- {dd}
- {HH}
- {hh}
- {mm}
- {tt}

A possible output could be:

CustomFFUNameTemplate:
'{Name}\_{DisplayVersion}\_{SKU}\_Apps\_{yyyy}-{MM}-{dd}'

FFU file name:
Win11_23H2_Pro_Apps_2024-09-27.ffu