### PR TITLE
2410.1 Allow vhdx caching

### DIFF
--- a/FFUDevelopment/BuildFFUVM.ps1
+++ b/FFUDevelopment/BuildFFUVM.ps1
@@ -2863,11 +2863,12 @@ function Optimize-FFUCaptureDrive {
     )
     try {
         WriteLog 'Mounting VHDX for volume optimization'
-        Mount-VHD -Path $VhdxPath
+        $mountedDisk = Mount-VHD -Path $VhdxPath -Passthru | Get-Disk
+        $osPartition = $mountedDisk | Get-Partition | Where-Object { $_.GptType -eq "{ebd0a0a2-b9e5-4433-87c0-68b6b72699c7}" }
         WriteLog 'Defragmenting Windows partition...'
-        Optimize-Volume -DriveLetter W -Defrag -NormalPriority -Verbose 
+        Optimize-Volume -DriveLetter $osPartition.DriveLetter -Defrag -NormalPriority -Verbose 
         WriteLog 'Performing slab consolidation on Windows partition...'
-        Optimize-Volume -DriveLetter W -SlabConsolidate -NormalPriority -Verbose
+        Optimize-Volume -DriveLetter $osPartition.DriveLetter -SlabConsolidate -NormalPriority -Verbose
         WriteLog 'Dismounting VHDX'
         Dismount-ScratchVhdx -VhdxPath $VhdxPath
         WriteLog 'Mounting VHDX as read-only for optimization'


### PR DESCRIPTION
This pull request adds the parameter $AllowVHDXCaching to the script.

Setting the $AllowVHDXCaching parameter to $true will create a VHDXCache folder that caches patched VHDX files together with their patch configuration.

On subsequent runs, the script scans for pre-built VHDX files and copies them for the next steps.

This can cut build times in half since only the app install part in the vm will be executed.