### PR TITLE
2410.1 Custom FFU names

### DIFF
--- a/FFUDevelopment/BuildFFUVM.ps1
+++ b/FFUDevelopment/BuildFFUVM.ps1
@@ -172,6 +172,9 @@ Model of the device to download drivers. This is required if Make is set.
 .PARAMETER AppsScriptVariables
 When passed a hashtable, the script will alter the $FFUDevelopmentPath\Apps\InstallAppsandSysprep.cmd file to set variables with the hashtable keys as variable names and the hashtable values their content.
 
+.PARAMETER CustomFFUNameTemplate
+Sets a custom FFU output name with placeholders. Allowed placeholders are: {Name}, {DisplayVersion}, {SKU}, {BuildDate}, {yyyy}, {MM}, {dd}, {H}, {hh}, {mm}, {tt}
+
 .EXAMPLE
 Command line for most people who want to download the latest Windows 11 Pro x64 media in English (US) with the latest Windows Cumulative Update, .NET Framework, Defender platform and definition updates, Edge, OneDrive, and Office/M365 Apps. It will also copy drivers to the FFU. This can take about 40 minutes to create the FFU due to the time it takes to download and install the updates.
 .\BuildFFUVM.ps1 -WindowsSKU 'Pro' -Installapps $true -InstallOffice $true -InstallDrivers $true -VMSwitchName 'Name of your VM Switch in Hyper-V' -VMHostIPAddress 'Your IP Address' -CreateCaptureMedia $true -CreateDeploymentMedia $true -BuildUSBDrive $true -UpdateLatestCU $true -UpdateLatestNet $true -UpdateLatestDefender $true -UpdateEdge $true -UpdateOneDrive $true -verbose
@@ -239,8 +242,9 @@ param(
     [string]$VMLocation,
     [string]$FFUPrefix = '_FFU',
     [string]$FFUCaptureLocation,
-    [String]$ShareName = "FFUCaptureShare",
+    [string]$ShareName = "FFUCaptureShare",
     [string]$Username = "ffu_user",
+    [string]$CustomFFUNameTemplate,
     [Parameter(Mandatory = $false)]
     [string]$VMHostIPAddress,
     [bool]$CreateCaptureMedia = $true,
@@ -2772,6 +2776,11 @@ Function Set-CaptureFFU {
         $ScriptContent = Get-Content -Path $CaptureFFUScriptPath
         $UpdatedContent = $ScriptContent -replace '(net use).*', ("$SharePath")
         WriteLog 'Updating share command in CaptureFFU.ps1 script with new share information'
+	$UpdatedContent = $UpdatedContent -replace '^\$CustomFFUNameTemplate \= .*#Custom naming', "#Custom naming placeholder"
+	if (![string]::IsNullOrEmpty($CustomFFUNameTemplate)) {
+            $UpdatedContent = $UpdatedContent -replace '#Custom naming placeholder', ("`$CustomFFUNameTemplate = '$CustomFFUNameTemplate' #Custom naming")
+	    WriteLog 'Updating share command in CaptureFFU.ps1 script with new ffu name template information'
+        }
         Set-Content -Path $CaptureFFUScriptPath -Value $UpdatedContent
         WriteLog 'Update complete'
     }

--- a/FFUDevelopment/WinPECaptureFFUFiles/CaptureFFU.ps1
+++ b/FFUDevelopment/WinPECaptureFFUFiles/CaptureFFU.ps1
@@ -1,5 +1,6 @@
 #Modify the net use W: \\192.168.1.158\FFUCaptureShare /user:ffu_user ddb1f077-3eed-433c-b4d9-7b8cd54ce727
 net use W: \\192.168.1.158\FFUCaptureShare /user:ffu_user ddb1f077-3eed-433c-b4d9-7b8cd54ce727
+#Custom naming placeholder
 
 $AssignDriveLetter = 'x:\AssignDriveLetter.txt'
 Start-Process -FilePath diskpart.exe -ArgumentList "/S $AssignDriveLetter" -Wait -ErrorAction Stop | Out-Null
@@ -55,16 +56,31 @@ if ($InstallationType -eq "Client") {
 #If Office is installed, modify the file name of the FFU
 #$Office = Get-childitem -Path 'M:\Program Files\Microsoft Office' -ErrorAction SilentlyContinue | Out-Null
 $Office = Get-childitem -Path 'M:\Program Files\Microsoft Office' -ErrorAction SilentlyContinue
-if($Office){
+if ($Office) {
     $ffuFilePath = "W:\$Name`_$DisplayVersion`_$SKU`_Office`_$BuildDate.ffu"
-    $dismArgs = "/capture-ffu /imagefile=$ffuFilePath /capturedrive=\\.\PhysicalDrive0 /name:$Name$DisplayVersion$SKU /Compress:Default"
-    
-    
-}
-else{
+} else {
     $ffuFilePath = "W:\$Name`_$DisplayVersion`_$SKU`_Apps`_$BuildDate.ffu"
-    $dismArgs = "/capture-ffu /imagefile=$ffuFilePath /capturedrive=\\.\PhysicalDrive0 /name:$Name$DisplayVersion$SKU /Compress:Default"
-    
+}
+$dismArgs = "/capture-ffu /imagefile=$ffuFilePath /capturedrive=\\.\PhysicalDrive0 /name:$Name$DisplayVersion$SKU /Compress:Default"
+
+if (![string]::IsNullOrEmpty($CustomFFUNameTemplate)) {
+    $CustomFFUNameTemplate = $CustomFFUNameTemplate -replace "{Name}", $Name
+    $CustomFFUNameTemplate = $CustomFFUNameTemplate -replace "{DisplayVersion}", $DisplayVersion
+    $CustomFFUNameTemplate = $CustomFFUNameTemplate -replace "{SKU}", $SKU
+    $CustomFFUNameTemplate = $CustomFFUNameTemplate -replace "{BuildDate}", $BuildDate
+    $CustomFFUNameTemplate = $CustomFFUNameTemplate -replace "{yyyy}", (Get-Date -UFormat "%Y")
+    $CustomFFUNameTemplate = $CustomFFUNameTemplate -replace "{MM}", (Get-Date -UFormat "%m")
+    $CustomFFUNameTemplate = $CustomFFUNameTemplate -replace "{dd}", (Get-Date -UFormat "%d")
+    $CustomFFUNameTemplate = $CustomFFUNameTemplate -replace "{HH}", (Get-Date -UFormat "%H")
+    $CustomFFUNameTemplate = $CustomFFUNameTemplate -replace "{hh}", (Get-Date -UFormat "%I")
+    $CustomFFUNameTemplate = $CustomFFUNameTemplate -replace "{mm}", (Get-Date -UFormat "%M")
+    $CustomFFUNameTemplate = $CustomFFUNameTemplate -replace "{tt}", (Get-Date -UFormat "%p")
+
+    if (!$CustomFFUNameTemplate.EndsWith(".ffu")) {
+        $CustomFFUNameTemplate += ".ffu"
+    }
+
+    $dismArgs = "/capture-ffu /imagefile=W:\$CustomFFUNameTemplate /capturedrive=\\.\PhysicalDrive0 /name:$Name$DisplayVersion$SKU /Compress:Default"
 }
 
 #Unload Registry


### PR DESCRIPTION
Add the parameter CustomFFUNameTemplate that allows to set a custom name for the output FFU file.

Implemented placeholders are:

{Name}
{DisplayVersion}
{SKU}
{BuildDate}
{yyyy}
{MM}
{dd}
{HH}
{hh}
{mm}
{tt}
A possible output could be:

CustomFFUNameTemplate:
'{Name}_{DisplayVersion}_{SKU}_Apps_{yyyy}-{MM}-{dd}'

FFU file name:
Win11_23H2_Pro_Apps_2024-09-27.ffu

This pull request replaces the previous one and is now in sync with the current 2410.1 branch.