### PR TITLE
Add initial support for reusing drivers as PE drivers

### DIFF
--- a/FFUDevelopment/BuildFFUVM.ps1
+++ b/FFUDevelopment/BuildFFUVM.ps1
@@ -3057,7 +3057,7 @@ function Copy-Drivers {
             
             WriteLog "Copying PE drivers for $providerName"
             if (!(Test-Path -Path $targetPath)) {
-                New-Item -Path $targetPath -ItemType Directory
+                [void](New-Item -Path $targetPath -ItemType Directory)
             }
             Copy-Item -Path $iniFullName -Destination $targetPath -Force
             $CatalogFileName = Get-PrivateProfileString -FileName $iniFullName -SectionName "version" -KeyName "Catalogfile"

--- a/FFUDevelopment/BuildFFUVM.ps1
+++ b/FFUDevelopment/BuildFFUVM.ps1
@@ -429,10 +429,7 @@ public static extern uint GetPrivateProfileString(
     System.Text.StringBuilder lpReturnedString,
     uint nSize,
     string lpFileName);
-'@
-Add-Type -MemberDefinition $definition -Namespace Win32 -Name Kernel32 -PassThru
 
-$definition = @'
 [DllImport("kernel32.dll", CharSet = CharSet.Auto)]
 public static extern uint GetPrivateProfileSection(
     string lpAppName,

--- a/FFUDevelopment/BuildFFUVM.ps1
+++ b/FFUDevelopment/BuildFFUVM.ps1
@@ -3041,8 +3041,8 @@ function Copy-Drivers {
     )
     #Find more information about device classes here:
     #https://learn.microsoft.com/en-us/windows-hardware/drivers/install/system-defined-device-setup-classes-available-to-vendors
-    #For now, included are system devices, scsi and raid controllers, keyboards and mice
-    $filterGUIDs = @("{4D36E97D-E325-11CE-BFC1-08002BE10318}", "{4D36E97B-E325-11CE-BFC1-08002BE10318}", "{4d36e96b-e325-11ce-bfc1-08002be10318}", "{d36e96f-e325-11ce-bfc1-08002be10318}")
+    #For now, included are system devices, scsi and raid controllers, keyboards, mice and HID devices for touch support
+    $filterGUIDs = @("{4D36E97D-E325-11CE-BFC1-08002BE10318}", "{4D36E97B-E325-11CE-BFC1-08002BE10318}", "{4d36e96b-e325-11ce-bfc1-08002be10318}", "{d36e96f-e325-11ce-bfc1-08002be10318}", "{745a17a0-74d3-11d0-b6fe-00a0c90f57da}")
     $exclusionList = "wdmaudio.inf|Sound|Machine Learning|Camera|Firmware"
     $pathLength = $Path.Length
     $infFiles = Get-ChildItem -Path $Path -Recurse -Filter "*.inf"

--- a/FFUDevelopment/BuildFFUVM.ps1
+++ b/FFUDevelopment/BuildFFUVM.ps1
@@ -3043,6 +3043,7 @@ function Copy-Drivers {
     #https://learn.microsoft.com/en-us/windows-hardware/drivers/install/system-defined-device-setup-classes-available-to-vendors
     #For now, included are system devices, scsi and raid controllers, keyboards and mice
     $filterGUIDs = @("{4D36E97D-E325-11CE-BFC1-08002BE10318}", "{4D36E97B-E325-11CE-BFC1-08002BE10318}", "{4d36e96b-e325-11ce-bfc1-08002be10318}", "{d36e96f-e325-11ce-bfc1-08002be10318}")
+    $exclusionList = "wdmaudio.inf|Sound|Machine Learning|Camera|Firmware"
     $pathLength = $Path.Length
     $infFiles = Get-ChildItem -Path $Path -Recurse -Filter "*.inf"
  
@@ -3053,9 +3054,9 @@ function Copy-Drivers {
         $targetPath = Join-Path -Path $Output -ChildPath $childPath
         
         if ((Get-PrivateProfileString -FileName $infFullName -SectionName "version" -KeyName "ClassGUID") -in $filterGUIDs) {
-            #Avoid drivers that reference wdmaudio.inf or contain Smart Sound
-            if (((Get-Content -Path $infFullName) -match "wdmaudio.inf|Smart Sound").Length -eq 0) {
-                $providerName = (Get-PrivateProfileString -FileName $infFullName -SectionName "Provider" -KeyName "Catalogfile").Trim("%")
+            #Avoid drivers that reference keywords from the exclusion list to keep the total size small
+            if (((Get-Content -Path $infFullName) -match $exclusionList).Length -eq 0) {
+                $providerName = (Get-PrivateProfileString -FileName $infFullName -SectionName "Version" -KeyName "Provider").Trim("%")
                 
                 WriteLog "Copying PE drivers for $providerName"
                 WriteLog "Driver inf is: $infFullName"

--- a/FFUDevelopment/BuildFFUVM.ps1
+++ b/FFUDevelopment/BuildFFUVM.ps1
@@ -3044,7 +3044,7 @@ function Copy-Drivers {
     #For now, included are system devices, scsi and raid controllers, keyboards and mice
     $filterGUIDs = @("{4D36E97D-E325-11CE-BFC1-08002BE10318}", "{4D36E97B-E325-11CE-BFC1-08002BE10318}", "{4d36e96b-e325-11ce-bfc1-08002be10318}", "{d36e96f-e325-11ce-bfc1-08002be10318}")
     $pathLength = $Path.Length
-    $iniFiles = Get-ChildItem -Path $Path -Recurse -Filter "*.ini"
+    $iniFiles = Get-ChildItem -Path $Path -Recurse -Filter "*.inf"
  
     for ($i = 0; $i -lt $iniFiles.Count; $i++) {
         $iniFullName = $iniFiles[$i].FullName
@@ -3056,6 +3056,9 @@ function Copy-Drivers {
             $providerName = (Get-PrivateProfileString -FileName $iniFullName -SectionName "Provider" -KeyName "Catalogfile").Trim("%")
             
             WriteLog "Copying PE drivers for $providerName"
+            if (!(Test-Path -Path $targetPath)) {
+                New-Item -Path $targetPath -ItemType Directory
+            }
             Copy-Item -Path $iniFullName -Destination $targetPath -Force
             $CatalogFileName = Get-PrivateProfileString -FileName $iniFullName -SectionName "version" -KeyName "Catalogfile"
             Copy-Item -Path "$iniPath\$CatalogFileName" -Destination $targetPath -Force


### PR DESCRIPTION
- Add functions to read data from driver .ini files
- Copy driver files required into the PE driver folder for system devices, scsi and raid controllers, keyboards and mice

This PR should filter and copy the files for the PE stage. I'll test the code and add fixes as required.

@rbalsleyMSFT 
This should minimize the amount of copied files for the PE stage while enabling the usage of all necessary devices.