### PR TITLE
Fix HP Driver Windows Version case sensitivity

### DIFF
--- a/FFUDevelopment/BuildFFUVM.ps1
+++ b/FFUDevelopment/BuildFFUVM.ps1
@@ -1003,7 +1003,9 @@ function Get-HPDrivers {
     $Arch = $WindowsArch -replace "^x", ""
 
     # Construct the URL to download the driver XML cab for the model
-    $ModelRelease = $SystemID + "_$Arch" + "_$WindowsRelease" + ".0.$WindowsVersion"
+    # The HPcloud reference site is case sensitve so we must convert the Windowsversion to lower 'h' first
+    $WindowsVersionHP = $WindowsVersion -replace 'H', 'h'
+    $ModelRelease = $SystemID + "_$Arch" + "_$WindowsRelease" + ".0.$WindowsVersionHP"
     $DriverCabUrl = "https://hpia.hpcloud.hp.com/ref/$SystemID/$ModelRelease.cab"
     $DriverCabFile = "$DriversFolder\$ModelRelease.cab"
     $DriverXmlFile = "$DriversFolder\$ModelRelease.xml"


### PR DESCRIPTION
Some people are using a value of '24H2' or '24H3' for the Variable $WindowVersion at the command prompt to override the default Parameter 

```[string]$WindowsVersion = '24h2', ```

This is the cause for the .cab download failure for HP Drivers as the HPCloud site is case sensitive and reason for issue:
-  #118 

This Fix will replace the uppercase 'H' with the lowercase 'h' for the HP Drivers Download function. 


