### PR TITLE
WinPE time zone fix

### DIFF
--- a/FFUDevelopment/BuildFFUVM.ps1
+++ b/FFUDevelopment/BuildFFUVM.ps1
@@ -2991,6 +2991,9 @@ function New-PEMedia {
         WriteLog "Copying $FFUDevelopmentPath\WinPECaptureFFUFiles\* to WinPE capture media"
         Copy-Item -Path "$FFUDevelopmentPath\WinPECaptureFFUFiles\*" -Destination "$WinPEFFUPath\mount" -Recurse -Force | out-null
         WriteLog "Copy complete"
+	WriteLog "Setting WinPE time zone to local time zone"
+        $LocalTimeZone = Get-TimeZone
+        Dism /Image:"$($WinPEFFUPath)\mount" /Set-TimeZone:"$($LocalTimeZone.Id)"
         #Remove Bootfix.bin - for BIOS systems, shouldn't be needed, but doesn't hurt to remove for our purposes
         #Remove-Item -Path "$WinPEFFUPath\media\boot\bootfix.bin" -Force | Out-null
         # $WinPEISOName = 'WinPE_FFU_Capture.iso'


### PR DESCRIPTION
- Adds a fix so the Windows PE of the capture ISO uses the local time zone to improve image timestamp values

The capturing Windows PE uses a pre-set time zone of GMT-8. This is alright for most purposes. However if you're building images in different locations in the US or in the UK, the offset can become a noticeable irritation.

It might be a good idea to also offer UTC+0 timestamps, depending on demand.