### PR TITLE
FFU vm and WinPE time zone fix

### DIFF
--- a/FFUDevelopment/BuildFFUVM.ps1
+++ b/FFUDevelopment/BuildFFUVM.ps1
@@ -2915,6 +2915,9 @@ function New-FFUVM {
     Set-VMKeyProtector -VMName $VMName -KeyProtector $kp.RawData
     Enable-VMTPM -VMName $VMName
 
+    #Enable time sync
+    Enable-VMIntegrationService -VMName $VMName -Name "Time Synchronization"
+
     #Connect to VM
     WriteLog "Starting vmconnect localhost $VMName"
     & vmconnect localhost "$VMName"
@@ -3039,6 +3042,9 @@ function New-PEMedia {
         WriteLog "Copying $FFUDevelopmentPath\WinPECaptureFFUFiles\* to WinPE capture media"
         Copy-Item -Path "$FFUDevelopmentPath\WinPECaptureFFUFiles\*" -Destination "$WinPEFFUPath\mount" -Recurse -Force | out-null
         WriteLog "Copy complete"
+        WriteLog "Setting WinPE time zone to local time zone"
+        $LocalTimeZone = Get-TimeZone
+        Dism /Image:"$($WinPEFFUPath)\mount" /Set-TimeZone:"$($LocalTimeZone.Id)"
         #Remove Bootfix.bin - for BIOS systems, shouldn't be needed, but doesn't hurt to remove for our purposes
         #Remove-Item -Path "$WinPEFFUPath\media\boot\bootfix.bin" -Force | Out-null
         # $WinPEISOName = 'WinPE_FFU_Capture.iso'
@@ -4795,6 +4801,10 @@ try {
         $WindowsPartition = $osPartitionDriveLetter + ':\'
 
     }
+    
+    WriteLog "Setting FFU vm time zone to local time zone"
+    $LocalTimeZone = Get-TimeZone
+    Dism /Image:"$($WindowsPartition)" /Set-TimeZone:"$($LocalTimeZone.Id)"
 
     #Set Product key
     If ($ProductKey) {


### PR DESCRIPTION
- Adds a fix so the Windows PE of the capture ISO uses the local time zone to improve image timestamp values

The capturing FFU vm and Windows PE use a pre-set time zone of GMT-8. This is alright for most purposes. However if you're building images in different locations in the US or in the UK, the offset can become a noticeable irritation. This should allow users to see the local time stamps for the FFU vm logs as well for the captured FFU file name.

It might be a good idea to also offer UTC+0 time or a specific time zone provided through a parameter, depending on demand.