### PR TITLE
Lenovo MTM Append to Drivers Folder

### DIFF
--- a/FFUDevelopment/BuildFFUVM.ps1
+++ b/FFUDevelopment/BuildFFUVM.ps1
@@ -1177,7 +1177,7 @@ function Get-LenovoDrivers {
     }
 
     # Create the folder structure for the Lenovo drivers
-    $driversFolder = "$DriversFolder\$Make"
+     $driversFolder = "$DriversFolder\$model ($machineType)"
     if (-not (Test-Path -Path $DriversFolder)) {
         WriteLog "Creating Drivers folder: $DriversFolder"
         New-Item -Path $DriversFolder -ItemType Directory -Force | Out-Null


### PR DESCRIPTION
Add Lenovo Machine Type Label to Drivers Folder Directory

![image](https://github.com/user-attachments/assets/c6725492-4cf7-4a23-a5e2-a48c5ac45ec9)


- Better Folder organization when multiple models are discovered and written out for the Selection Table. Issue referenced in:
-#135 