### PR TITLE
Update USBImagingToolCreator.ps1

### DIFF
--- a/FFUDevelopment/USBImagingToolCreator.ps1
+++ b/FFUDevelopment/USBImagingToolCreator.ps1
@@ -28,7 +28,7 @@ function Write-ProgressLog {
     }
 Function Get-RemovableDrive {
 writelog "Get information for all removable drives"
-$USBDrives = Get-WmiObject Win32_DiskDrive | Where-Object {$_.MediaType -eq "Removable media"} 
+$USBDrives = Get-WmiObject Win32_DiskDrive | Where-Object {$_.MediaType -eq "Removable media" -or $_.MediaType -eq "External hard disk media"} 
 If($USBDrives -and ($null -eq $USBDrives.count)) {
         $USBDrivesCount = 1
     } else {
@@ -62,6 +62,7 @@ Function Build-DeploymentUSB{
             $ScriptBlock = {
             param($DriveNumber)
             Clear-Disk -Number $DriveNumber -RemoveData -RemoveOEM -Confirm:$false
+			Initialize-Disk -Number $DriveNumber
             $Disk = Get-Disk -Number $DriveNumber
             $PartitionStyle = $Disk.PartitionStyle
             if($PartitionStyle -ne 'MBR'){


### PR DESCRIPTION
Added External hard disk media type and make sure disk is initialized. SanDisk Extreme Pro USB Drives show up as external hard disk media and do not re-initialize after cleared. 