### PR TITLE
adding a simple try/catch for cases where the VM fails to start

### DIFF
--- a/FFUDevelopment/BuildFFUVM.ps1
+++ b/FFUDevelopment/BuildFFUVM.ps1
@@ -3049,7 +3049,13 @@ function New-FFUVM {
     & vmconnect localhost "$VMName"
 
     #Start VM
-    Start-VM -Name $VMName
+    try{
+        Start-VM -Name $VMName -ErrorAction Stop
+    }
+    catch{
+        WriteLog "Error starting VM: $_"
+        throw $_
+    }
 
     return $VM
 }


### PR DESCRIPTION
This PR adds a simple try/catch when starting the newly created VM. Currently, it can fail to start and the script will continue running and ultimately fail.