### PR TITLE
Fix working directory handling and improve build processes

### DIFF
--- a/FFUDevelopment/BuildFFUVM.ps1
+++ b/FFUDevelopment/BuildFFUVM.ps1
@@ -5692,7 +5692,8 @@ If (Test-Path -Path "$FFUDevelopmentPath\dirty.txt") {
     Get-FFUEnvironment
 }
 WriteLog 'Creating dirty.txt file'
-New-Item -Path .\ -Name "dirty.txt" -ItemType "file" | Out-Null
+$dirtyFilePath = Join-Path -Path $FFUDevelopmentPath -ChildPath 'dirty.txt'
+New-Item -Path $dirtyFilePath -ItemType "file" | Out-Null
 
 # Early CLI prompt for additional FFUs (only if enabled and not provided)
 if ($BuildUSBDrive -and $CopyAdditionalFFUFiles -and ((-not $AdditionalFFUFiles) -or ($AdditionalFFUFiles.Count -eq 0))) {
@@ -7615,7 +7616,8 @@ else {
 }
 
 #Clean up dirty.txt file
-Remove-Item -Path .\dirty.txt -Force | out-null
+$dirtyFilePath = Join-Path -Path $FFUDevelopmentPath -ChildPath 'dirty.txt'
+Remove-Item -Path $dirtyFilePath -Force | out-null
 # Remove per-run session folder if present
 $sessionDir = Join-Path $FFUDevelopmentPath '.session'
 if (Test-Path -Path $sessionDir) { 

--- a/FFUDevelopment/BuildFFUVM.ps1
+++ b/FFUDevelopment/BuildFFUVM.ps1
@@ -464,7 +464,7 @@ param(
     [switch]$Cleanup
 )
 $ProgressPreference = 'SilentlyContinue'
-$version = '2603.1'
+$version = '2603.2'
 
 # Remove any existing modules to avoid conflicts
 if (Get-Module -Name 'FFU.Common.Core' -ErrorAction SilentlyContinue) {
@@ -2781,11 +2781,25 @@ function Add-BootFiles {
         [string]$OsPartitionDriveLetter,
         [Parameter(Mandatory = $true)]
         [string]$SystemPartitionDriveLetter,
+        [Parameter(Mandatory = $true)]
+        [string]$AdkPath,
+        [Parameter(Mandatory = $true)]
+        [ValidateSet('x86', 'x64', 'arm64')]
+        [string]$WindowsArch,
         [string]$FirmwareType = 'UEFI'
     )
 
-    WriteLog "Adding boot files for `"$($OsPartitionDriveLetter):\Windows`" to System partition `"$($SystemPartitionDriveLetter):`"..."
-    Invoke-Process bcdboot "$($OsPartitionDriveLetter):\Windows /S $($SystemPartitionDriveLetter): /F $FirmwareType" | Out-Null
+    # Use the ADK copy of BCDBoot so the boot binaries come from the validated ADK toolset
+    # instead of the local OS installation, which can differ based on Secure Boot servicing state.
+    $bcdBootArchitecture = if ($WindowsArch -ieq 'arm64') { 'arm64' } else { 'amd64' }
+    $bcdBootPath = Join-Path $AdkPath "Assessment and Deployment Kit\Deployment Tools\$bcdBootArchitecture\BCDBoot\bcdboot.exe"
+
+    if (-not (Test-Path -Path $bcdBootPath)) {
+        throw "ADK BCDBoot was not found at $bcdBootPath"
+    }
+
+    WriteLog "Adding boot files for `"$($OsPartitionDriveLetter):\Windows`" to System partition `"$($SystemPartitionDriveLetter):`" using ADK BCDBoot at `"$bcdBootPath`"..."
+    Invoke-Process $bcdBootPath "$($OsPartitionDriveLetter):\Windows /S $($SystemPartitionDriveLetter): /F $FirmwareType" | Out-Null
     WriteLog "Done."
 }
 
@@ -7025,7 +7039,7 @@ try {
 
         WriteLog 'All necessary partitions created.'
 
-        Add-BootFiles -OsPartitionDriveLetter $osPartitionDriveLetter -SystemPartitionDriveLetter $systemPartitionDriveLetter[1]
+        Add-BootFiles -OsPartitionDriveLetter $osPartitionDriveLetter -SystemPartitionDriveLetter $systemPartitionDriveLetter[1] -AdkPath $adkPath -WindowsArch $WindowsArch
     
         #Add Windows packages
         if ($UpdateLatestCU -or $UpdateLatestNet -or $UpdatePreviewCU ) {

--- a/FFUDevelopment/BuildFFUVM_UI.ps1
+++ b/FFUDevelopment/BuildFFUVM_UI.ps1
@@ -293,9 +293,10 @@ $script:uiState.Controls.btnRun.Add_Click({
                 )
 
                 $startCleanupParams = @{
-                    FilePath     = $pwshPath
-                    ArgumentList = $cleanupArgs
-                    PassThru     = $true
+                    FilePath         = $pwshPath
+                    ArgumentList     = $cleanupArgs
+                    WorkingDirectory = $ffuDevPath
+                    PassThru         = $true
                 }
                 if ($Host.Name -eq 'ConsoleHost') {
                     $startCleanupParams['NoNewWindow'] = $true
@@ -455,9 +456,10 @@ $script:uiState.Controls.btnRun.Add_Click({
             }
 
             $startBuildParams = @{
-                FilePath     = $pwshPath
-                ArgumentList = $pwshArgs
-                PassThru     = $true
+                FilePath         = $pwshPath
+                ArgumentList     = $pwshArgs
+                WorkingDirectory = $config.FFUDevelopmentPath
+                PassThru         = $true
             }
             if ($Host.Name -eq 'ConsoleHost') {
                 $startBuildParams['NoNewWindow'] = $true

--- a/FFUDevelopment/WinPEDeployFFUFiles/ApplyFFU.ps1
+++ b/FFUDevelopment/WinPEDeployFFUFiles/ApplyFFU.ps1
@@ -835,7 +835,7 @@ $LogFileName = 'ScriptLog.txt'
 $USBDrive = Get-USBDrive
 New-item -Path $USBDrive -Name $LogFileName -ItemType "file" -Force | Out-Null
 $LogFile = $USBDrive + $LogFilename
-$version = '2603.1'
+$version = '2603.2'
 WriteLog 'Begin Logging'
 WriteLog "Script version: $version"
 


### PR DESCRIPTION
This pull request introduces several improvements and fixes to the FFU development scripts, focusing on increased reliability, consistency, and the use of validated toolsets. The most significant changes involve switching to the ADK version of BCDBoot for boot file operations, improving file path handling for the `dirty.txt` marker, and ensuring build and cleanup processes always run in the correct working directory.

**Boot file management improvements:**
* The `Add-BootFiles` function now requires explicit `AdkPath` and `WindowsArch` parameters and uses the ADK-provided `bcdboot.exe` instead of the system version, ensuring consistent and validated boot binaries are used. It also validates the existence of the ADK BCDBoot executable and throws an error if not found. [[1]](diffhunk://#diff-3d82e35cafeccf587c74955a4c17b7f978e2d4fb2b9e1bd2e75b2e80dfc355c5R2784-R2802) [[2]](diffhunk://#diff-3d82e35cafeccf587c74955a4c17b7f978e2d4fb2b9e1bd2e75b2e80dfc355c5L7027-R7042)

**File path consistency and reliability:**
* Creation and deletion of the `dirty.txt` marker file now use an explicit path based on `$FFUDevelopmentPath`, avoiding ambiguity and potential issues with relative paths. [[1]](diffhunk://#diff-3d82e35cafeccf587c74955a4c17b7f978e2d4fb2b9e1bd2e75b2e80dfc355c5L5695-R5710) [[2]](diffhunk://#diff-3d82e35cafeccf587c74955a4c17b7f978e2d4fb2b9e1bd2e75b2e80dfc355c5L7618-R7634)

**Process execution reliability:**
* The UI script (`BuildFFUVM_UI.ps1`) now sets the `WorkingDirectory` for both build and cleanup subprocesses, ensuring they execute in the intended directory and improving reliability across different environments. [[1]](diffhunk://#diff-f681ca32a38d37192e2701ba5ce1b562f0d2ce35f268f711f5ac4880db0ae5deR298) [[2]](diffhunk://#diff-f681ca32a38d37192e2701ba5ce1b562f0d2ce35f268f711f5ac4880db0ae5deR461)

**Version updates:**
* The script version number is incremented from `2603.1` to `2603.2` in both `BuildFFUVM.ps1` and `ApplyFFU.ps1`. [[1]](diffhunk://#diff-3d82e35cafeccf587c74955a4c17b7f978e2d4fb2b9e1bd2e75b2e80dfc355c5L467-R467) [[2]](diffhunk://#diff-0e440ea375e2c2d241be21e0b19d4b296cc253bd676ba4b3f18df432d1d129f4L838-R838)