### PR TITLE
Update release notes and improve UI documentation and build process

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,29 @@
 # Change Log
 
+# 2603.2
+
+## What's Changed
+
+Highly recommended to upgrade to this release due to potential SecureBoot issues
+
+### Fixes SecureBoot-related boot issues on newly deployed FFUs
+
+Fixes an issue where some devices may not boot after an FFU was applied if the FFU was built from a machine that had been updated to the Windows UEFI CA 2023 SecureBoot certificates.
+
+Sometime at the start of this calendar year (Either January or February), a change was made in Windows to how BCDBoot functioned. If you took a CU from either of these months, BCDBoot will now check to see if the device has the 2011 or 2023 CA certificates. If 2023, the local BCDBoot will use the 2023 signed boot files when creating the System partition and these boot files will be deployed to the target system when the FFU is deployed. If the target machine hasn't updated to the 2023 certificates, boot will fail.
+
+To fix this, FFU Builder now uses the version of BCDBoot from the ADK instead of the locally installed version. The version of BCDBoot from the 10.1.26100.2454 ADK December 2024 version (which is what FFU Builder considers the latest), will provide the boot files signed with the 2011 certs.
+
+The version of [BCDBoot from the 10.1.28000.1 ADK](https://learn.microsoft.com/en-us/windows-hardware/get-started/what-s-new-in-kits-and-tools#bcd-boot) from November 2025 will default to using the 2023 certs as long as the machine supports the 2023 CA. This has been documented since this ADK was released. The behavior of this version of BCDBoot is what we're seeing now in devices that have been recently updated.
+
+I suspect that when 26H2 is released, there will be a new ADK around that time and at that point we'll move to using that version of the ADK, which that version of BCDBoot will default to using the 2023 signed boot files and I suspect WinPE will probably default to doing the same. By then, hopefully, most in-market devices should have the 2023 certificates in UEFI and those that don't will need to get the certs or downgrade their ADK version to use the 2011 signed boot files.
+
+### Fixes working directory handling
+
+Creation and deletion of the dirty.txt marker file now use an explicit path based on $FFUDevelopmentPath, avoiding ambiguity and potential issues with relative paths.
+
+**Full Changelog**: https://github.com/rbalsleyMSFT/FFU/compare/v2603.1...v2603.2
+
 # 2603.1
 
 ## What's Changed

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+# Updates
+
+## 2026-03-16 - [2603.2 Released](https://github.com/rbalsleyMSFT/FFU/releases)
+
+Fixes an issue with devices not booting after applying an FFU. Highly recommended you update today. 
+
 # Using Full Flash Update (FFU) files to speed up Windows deployment
 
 What if you could have a Windows image (Windows 10/11/Server/LTSC) that has:
@@ -20,7 +26,7 @@ The Full-Flash update (FFU) process can automatically download the latest releas
 
 # Getting Started
 
-If you're new, check out the [Quick Start Guide](https://rbalsleymsft.github.io/FFU/quickstart.html).
+If you're new to FFU Builder or new to the FFU Builder UI version, check out the [Quick Start Guide](https://rbalsleymsft.github.io/FFU/quickstart.html).
 
 This will be the fastest way to create your first FFU. There's a new [FFU Builder Quickstart Youtube video](https://youtu.be/kOIK5OmDugc) based on the 2602.1 UI Preview release.
 

--- a/docs/prerequisites.md
+++ b/docs/prerequisites.md
@@ -16,7 +16,7 @@ If possible, use an unmanaged Windows 11 or Windows Server machine. In some envi
 
 FFU Builder creates a 50GB dynamic VHDX disk by default which can be configured larger if that's not big enough. When the latest updated Windows media is installed to the VHDX, the VHDX size by itself will be about 15GB or so. If you service the media with the latest CU, that could grow the VHDX by double (~30GB in this case). If you install Office, additional applications, drivers, etc. the VHDX can get large quick. The FFU capture process will compress the size significantly, but between the VHDX size, the Windows media, the application and driver source content, the captured FFU, WinPE, etc. you can easily have over 100GB of used space.
 
-So err on the side of having more free disk space. **Recommended to have at least 100GB free disk space**. 
+So err on the side of having more free disk space. **Recommended to have at least 100GB free disk space**.
 
 ## Enable Hyper-V
 
@@ -47,7 +47,7 @@ Once Hyper-V has been enabled and you have rebooted, create either an external o
 
 If you haven't [downloaded the latest release yet, do so](https://github.com/rbalsleyMSFT/FFU/releases)
 
-Once downloaded, extract the zip file to `C:\FFUDevelopment`. You can use another location, just be sure set your FFUDevelopmentPath to the new location (e.g. `D:\FFUDevelopment`).
+Once downloaded, open the zip file and copy the content of the FFUDevelopment folder to `C:\FFUDevelopment`. You can use another location, just be sure set your FFUDevelopmentPath to the new location (e.g. `D:\FFUDevelopment`).
 
 After extraction, you most likely will need to unblock the files as they'll be tagged with the mark of the web. In PowerShell run:
 


### PR DESCRIPTION
This pull request introduces the 2603.2 release, which is a highly recommended update due to critical SecureBoot-related boot issues. The update also clarifies documentation around getting started and working directory usage. The most important changes are summarized below:

## Critical SecureBoot Fixes

* Updated FFU Builder to use the version of `BCDBoot` from the ADK (specifically 10.1.26100.2454) instead of the locally installed version, ensuring boot files signed with the 2011 certificates are used and fixing boot failures on devices lacking the 2023 UEFI CA certificates.

## Documentation Updates

* Added a new section in `README.md` announcing the 2603.2 release and recommending users update to resolve boot issues.
* Improved the description in the "Getting Started" section of `README.md` to clarify that both new FFU Builder and UI users should consult the Quick Start Guide.
* Clarified instructions in `docs/prerequisites.md` for extracting FFU Builder, specifying that users should copy the contents of the FFUDevelopment folder to the desired location.

## Working Directory Handling

* Fixed creation and deletion of the `dirty.txt` marker file to use an explicit path based on `$FFUDevelopmentPath`, avoiding ambiguity and issues with relative paths.