### PR TITLE
Eliminate UserAppList.json file name hardcoding

### DIFF
--- a/FFUDevelopment/Apps/Orchestration/Install-Win32Apps.ps1
+++ b/FFUDevelopment/Apps/Orchestration/Install-Win32Apps.ps1
@@ -249,8 +249,8 @@ function Install-Applications {
 
 # Define paths for the JSON files
 $wingetAppsJsonFile = "$PSScriptRoot\WinGetWin32Apps.json"
-# Look for UserAppList.json one directory level up from the script's location. This keeps the user specific json files (AppList.json and UserAppList.json in the Apps dir)
-$userAppsJsonFile = Join-Path -Path (Split-Path -Parent $PSScriptRoot) -ChildPath "UserAppList.json"
+# Look for UserAppListFinal.json one directory level up from the script's location. This keeps the user specific json files (AppList.json and UserAppList.json in the Apps dir)
+$userAppsJsonFile = Join-Path -Path (Split-Path -Parent $PSScriptRoot) -ChildPath "UserAppListFinal.json"
 
 # Initialize empty arrays for apps from each source
 $wingetApps = @()
@@ -288,7 +288,7 @@ if ($wingetApps.Count -gt 0) {
 
 # Read the UserAppList.json file if it exists
 if (Test-Path -Path $userAppsJsonFile) {
-    Write-Host "Processing UserAppList.json..."
+    Write-Host "Processing UserAppList..."
     try {
         $userContent = Get-Content -Path $userAppsJsonFile -Raw -ErrorAction Stop | ConvertFrom-Json
         if ($userContent -is [array]) {
@@ -300,15 +300,15 @@ if (Test-Path -Path $userAppsJsonFile) {
             Write-Host "Found 1 user-defined app."
         }
         else {
-            Write-Host "UserAppList.json is empty or invalid."
+            Write-Host "UserAppList is empty or invalid."
         }
     }
     catch {
-        Write-Error "Failed to read or parse UserAppList.json file: $_"
+        Write-Error "Failed to read or parse UserAppList file: $_"
     }
 }
 else {
-    Write-Host "UserAppList.json file not found. Skipping."
+    Write-Host "UserAppList file not found. Skipping."
 }
 
 # Install User apps if any were found
@@ -318,7 +318,7 @@ if ($userApps.Count -gt 0) {
 
 # Check if any apps were installed at all
 if ($wingetApps.Count -eq 0 -and $userApps.Count -eq 0) {
-    Write-Host "No Win32 apps found in either WinGetWin32Apps.json or UserAppList.json. Exiting."
+    Write-Host "No Win32 apps found in either WinGetWin32Apps.json or UserAppList. Exiting."
     exit 0
 }
 

--- a/FFUDevelopment/BuildFFUVM.ps1
+++ b/FFUDevelopment/BuildFFUVM.ps1
@@ -6215,6 +6215,7 @@ if ($InstallApps) {
                 foreach ($app in $userAppList) {
                     WriteLog "$($app.name)"
                 }
+                Copy-Item -Path $UserAppListPath -Destination "$AppsPath\UserAppListFinal.json"
             }
 
             # Remove residual update artifacts for any updates disabled via flags

--- a/FFUDevelopment/FFU.Common/FFU.Common.Cleanup.psm1
+++ b/FFUDevelopment/FFU.Common/FFU.Common.Cleanup.psm1
@@ -96,12 +96,23 @@ function Invoke-FFUPostBuildCleanup {
             }
         }
 
-        # Always remove LTSC update staging folder (out-of-band cleanup exception)
+
         if (-not [string]::IsNullOrWhiteSpace($AppsPath) -and (Test-Path -LiteralPath $AppsPath -PathType Container)) {
+            # Always remove LTSC update staging folder (out-of-band cleanup exception)
             $ltscUpdateFolder = Join-Path $AppsPath 'LTSCUpdate'
             if (Test-Path -LiteralPath $ltscUpdateFolder) {
                 WriteLog "CommonCleanup: Removing LTSC update staging folder $ltscUpdateFolder"
                 try { Remove-Item -LiteralPath $ltscUpdateFolder -Recurse -Force -ErrorAction Stop } catch { WriteLog "CommonCleanup: Failed removing $ltscUpdateFolder : $($_.Exception.Message)" }
+            }
+
+            $userAppListFinalPath = Join-Path $AppsPath "UserAppListFinal.json"
+            if (Test-Path -LiteralPath $userAppListFinalPath) {
+                try {
+                    WriteLog "CommonCleanup: Removing $userAppListFinalPath"
+                    Remove-Item -LiteralPath $userAppListFinalPath
+                } catch {
+                    WriteLog "CommonCleanup: Failed removing $userAppListFinalPath : $($_.Exception.Message)"
+                }
             }
         }
 


### PR DESCRIPTION
This PR fixes #441 by copying the provided UserAppListPath to UserAppListFinal.json (avoiding overwriting the original UserAppList.json file), and then pointing the orchestrator script at this file. It also adds a cleanup step to get rid of this temporary file. 